### PR TITLE
Complete python3 port of RLTest

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2018, Redis Labs Modules
+Portions Copyright (c) 2018, Red Hat
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # RLTest
-Redis Labs Test Framework, allow to run tests on redis and modules on verity of environments.
+Redis Labs Test Framework, runs tests on redis and modules on a variety of environments.
 
 Supported Environment: oss, oss-cluster, enterprise, enterprise-cluster
 
-The framework allow you to write a test without environment specification and then run the test on all supported environment.
+The framework allows you to write a test without environment specification and then run the test on all supported environments.
 
 # Install
 ```
@@ -31,7 +31,7 @@ usage: RLTest [-h] [--module MODULE] [--module-args MODULE_ARGS]
 ```
 
 ### module
-Load a spacific module to the environment, notice that on enterprise the file should be a zip file packed with [RAMP](https://github.com/RedisLabs/RAMP). might override by the test.
+Load a specific module to the environment, notice that on enterprise the file should be a zip file packed with [RAMP](https://github.com/RedisLabs/RAMP). might override by the test.
 
 ### module-args
 Pass arguments to the loaded module. might override by the test.
@@ -43,7 +43,7 @@ The environment on which to run the tests (oss,oss-cluster,enterprise,enterprise
 Path to the oss redis binary (default - redis-server)
 
 ### enterprise-redis-path
-Path to the enterprise redis binarty (default - ~/.RLTest/opt/redislabs/bin/redis-server).
+Path to the enterprise redis binary (default - ~/.RLTest/opt/redislabs/bin/redis-server).
 
 ### stop-on-failure
 Stop the tests run on failure, allows you to check what went wrong.
@@ -58,7 +58,7 @@ Stop before each test execution and allow you to attach to any process with debu
 Directory to search for tests (default - current directory).
 
 ### test-name
-Name of spacific test function to run.
+Name of specific test function to run.
 
 ### tests-file
 File inside the test_dir to search for tests (if not specified the framework searches in all files)
@@ -97,10 +97,10 @@ Run redis under valgrind (assuming valgrind is installed on the machine).
 Path to valgrind suppressions (not mandatory).
 
 ### interactive-debugger
-runs the redis on a debugger (gdb/lldb) interactivly.
-debugger interactive mode is only possible on a single process and so unsupported on cluste or with slaves.
+runs the redis on a debugger (gdb/lldb) interactively.
+debugger interactive mode is only possible on a single process and so unsupported on cluster or with slaves.
 it is also not possible to use valgrind on interactive debugger.
-interactive debugger direcly applies: --no-output-catch and --stop-on-failure.
+interactive debugger directly applies: --no-output-catch and --stop-on-failure.
 it is also implies that only one test will be run (if --inv-only was not specify), an error will be raise otherwise.
 
 ### debugger-args
@@ -117,7 +117,7 @@ RLTest @myConfig.txt # search for myConfig.txt configuration file
 ```
 The configuration file format is the same as the command line argument, i.e : '--< param_name > < param_val >'.
 
-It is also possible to comment a spacific lines in the configuration file using '#'.
+It is also possible to comment a specific lines in the configuration file using '#'.
 
 Example:
 ```

--- a/RLTest/Enterprise/CcsMock.py
+++ b/RLTest/Enterprise/CcsMock.py
@@ -40,15 +40,15 @@ class CcsMock():
             self.process = None
 
     def PrintEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'pid: %d' % self.process.pid)
-        print Colors.Yellow(prefix + 'unix socket: %s' % self.CCS_UNIX_SOCKET_DEFAULT_PATH)
-        print Colors.Yellow(prefix + 'binary path: %s' % self.redisBinaryPath)
+        print(Colors.Yellow(prefix + 'pid: %d' % self.process.pid))
+        print(Colors.Yellow(prefix + 'unix socket: %s' % self.CCS_UNIX_SOCKET_DEFAULT_PATH))
+        print(Colors.Yellow(prefix + 'binary path: %s' % self.redisBinaryPath))
         if self.directory:
-            print Colors.Yellow(prefix + 'db dir path: %s' % (self.directory))
-        print Colors.Yellow(prefix + 'rdb file name: %s' % (self.CCS_DB_RDB_FILE_NAME))
-        print Colors.Yellow(prefix + 'log file name: %s' % (self.CCS_LOG_FILE_NAME))
+            print(Colors.Yellow(prefix + 'db dir path: %s' % (self.directory)))
+        print(Colors.Yellow(prefix + 'rdb file name: %s' % (self.CCS_DB_RDB_FILE_NAME)))
+        print(Colors.Yellow(prefix + 'log file name: %s' % (self.CCS_LOG_FILE_NAME)))
         if self.libPath:
-            print Colors.Yellow(prefix + 'lib path: %s' % (self.libPath))
+            print(Colors.Yellow(prefix + 'lib path: %s' % (self.libPath)))
 
     def setup(self, shards, bdb_fields=None, endpoint_ccs_params=None, legacy_hash_slots=True, extra_keys=None):
 

--- a/RLTest/Enterprise/Dmc.py
+++ b/RLTest/Enterprise/Dmc.py
@@ -37,9 +37,9 @@ class Dmc():
         self.process = None
 
     def PrintEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'dmc binary path: %s' % self.dmcBinaryPath)
-        print Colors.Yellow(prefix + 'dmc env: %s' % str(self.env))
-        print Colors.Yellow(prefix + 'dir path: %s' % str(self.directory))
-        print Colors.Yellow(prefix + 'log file name: %s' % str(self.DMC_LOG_FILE_NAME))
+        print(Colors.Yellow(prefix + 'dmc binary path: %s' % self.dmcBinaryPath))
+        print(Colors.Yellow(prefix + 'dmc env: %s' % str(self.env)))
+        print(Colors.Yellow(prefix + 'dir path: %s' % str(self.directory)))
+        print(Colors.Yellow(prefix + 'log file name: %s' % str(self.DMC_LOG_FILE_NAME)))
         if self.libPath:
-            print Colors.Yellow(prefix + 'lib path: %s' % str(self.libPath))
+            print(Colors.Yellow(prefix + 'lib path: %s' % str(self.libPath)))

--- a/RLTest/Enterprise/EnterpriseClusterEnv.py
+++ b/RLTest/Enterprise/EnterpriseClusterEnv.py
@@ -1,7 +1,7 @@
 from RLTest.redis_std import StandardEnv
 from RLTest.utils import Colors, wait_for_conn
-from CcsMock import CcsMock
-from Dmc import Dmc
+from RLTest.Enterprise.CcsMock import CcsMock
+from RLTest.Enterprise.Dmc import Dmc
 import redis
 import os
 import json
@@ -60,21 +60,21 @@ class EnterpriseClusterEnv():
                 self.moduleArgs = self.moduleConfig['command_line_args']
 
     def printEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'bdb info:')
-        print Colors.Yellow(prefix + '\tlistening port:%d' % self.DMC_PORT)
-        print Colors.Yellow(prefix + '\tshards count:%d' % len(self.shards))
+        print(Colors.Yellow(prefix + 'bdb info:'))
+        print(Colors.Yellow(prefix + '\tlistening port:%d' % self.DMC_PORT))
+        print(Colors.Yellow(prefix + '\tshards count:%d' % len(self.shards)))
         if self.modulePath:
-            print Colors.Yellow(prefix + '\tzip module path:%s' % self.modulePath)
+            print(Colors.Yellow(prefix + '\tzip module path:%s' % self.modulePath))
         if self.moduleSoFilePath:
-            print Colors.Yellow(prefix + '\tso module path:%s' % self.moduleSoFilePath)
+            print(Colors.Yellow(prefix + '\tso module path:%s' % self.moduleSoFilePath))
         if self.moduleArgs:
-            print Colors.Yellow(prefix + '\tmodule args:%s' % self.moduleArgs)
+            print(Colors.Yellow(prefix + '\tmodule args:%s' % self.moduleArgs))
         for i, shard in enumerate(self.shards):
-            print Colors.Yellow(prefix + 'shard: %d' % (i + 1))
+            print(Colors.Yellow(prefix + 'shard: %d' % (i + 1)))
             shard.printEnvData(prefix + '\t')
-        print Colors.Yellow(prefix + 'ccs:')
+        print(Colors.Yellow(prefix + 'ccs:'))
         self.ccs.PrintEnvData(prefix + '\t')
-        print Colors.Yellow(prefix + 'dmc:')
+        print(Colors.Yellow(prefix + 'dmc:'))
         self.dmc.PrintEnvData(prefix + '\t')
 
     def startEnv(self):

--- a/RLTest/Enterprise/__init__.py
+++ b/RLTest/Enterprise/__init__.py
@@ -1,4 +1,4 @@
-from EnterpriseClusterEnv import EnterpriseClusterEnv
+from RLTest.Enterprise.EnterpriseClusterEnv import EnterpriseClusterEnv
 
 __all__ = [
     'EnterpriseClusterEnv'

--- a/RLTest/Enterprise/binaryrepo.py
+++ b/RLTest/Enterprise/binaryrepo.py
@@ -31,15 +31,15 @@ class BinaryRepository(object):
         self.debname = debname
 
     def download_binaries(self, binariesName='binaries.tar'):
-        print Colors.Yellow('installing enterprise binaries')
-        print Colors.Yellow('creating RLTest working dir: %s' % self.root)
+        print(Colors.Yellow('installing enterprise binaries'))
+        print(Colors.Yellow('creating RLTest working dir: %s' % self.root))
         try:
             shutil.rmtree(self.root)
             os.makedirs(self.root)
         except Exception:
             pass
 
-        print Colors.Yellow('download binaries')
+        print(Colors.Yellow('download binaries'))
         args = ['wget', self.url, '-O', os.path.join(self.root, binariesName)]
         process = subprocess.Popen(args=args, stdout=sys.stdout,
                                         stderr=sys.stdout)
@@ -47,7 +47,7 @@ class BinaryRepository(object):
         if process.poll() != 0:
             raise Exception('failed to download enterprise binaries from s3')
 
-        print Colors.Yellow('extracting binaries')
+        print(Colors.Yellow('extracting binaries'))
 
         args = ['tar', '-xvf', os.path.join(self.root, binariesName),
                 '--directory', self.root, self.debname]
@@ -58,6 +58,7 @@ class BinaryRepository(object):
                 'failed to extract binaries to %s' % self.self.root)
 
         # TODO: Support centos that does not have dpkg command
+        # rpm2cpio <self.rpmname> | cpio -idmv -D <os.path.join(self.root, self.rpmname)>
         args = ['dpkg', '-x', os.path.join(self.root, self.debname),
                 self.root]
         process = subprocess.Popen(args=args, stdout=sys.stdout,
@@ -67,4 +68,4 @@ class BinaryRepository(object):
             raise Exception(
                 'failed to extract binaries to %s' % self.self.root)
 
-        print Colors.Yellow('finished installing enterprise binaries')
+        print(Colors.Yellow('finished installing enterprise binaries'))

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -60,13 +60,13 @@ class MyCmd(cmd.Cmd):
         '''
         print
         '''
-        print 'print'
+        print('print')
 
     def do_stop(self, line):
         '''
         print
         '''
-        print 'BYE BYE'
+        print('BYE BYE')
         return True
 
     def do_cluster_conn(self, line):
@@ -75,16 +75,16 @@ class MyCmd(cmd.Cmd):
         '''
         if self.env.env == 'oss-cluster':
             self.env.con = self.env.envRunner.getClusterConnection()
-            print 'moved to cluster connection'
+            print('moved to cluster connection')
         else:
-            print 'cluster connection only available on oss-cluster env'
+            print('cluster connection only available on oss-cluster env')
 
     def do_normal_conn(self, line):
         '''
         move to normal connection (will connect to the first shard on oss-cluster)
         '''
         self.env.con = self.env.envRunner.getConnection()
-        print 'moved to normal connection (first shard on oss-cluster)'
+        print('moved to normal connection (first shard on oss-cluster)')
 
     do_exit = do_stop
 
@@ -234,13 +234,13 @@ class RLTest:
 
         if self.args.interactive_debugger:
             if self.args.env != 'oss' and self.args.env != 'enterprise':
-                print Colors.Bred('interactive debugger can only be used on non cluster env')
+                print(Colors.Bred('interactive debugger can only be used on non cluster env'))
                 sys.exit(1)
             if self.args.use_valgrind:
-                print Colors.Bred('can not use valgrind with interactive debugger')
+                print(Colors.Bred('can not use valgrind with interactive debugger'))
                 sys.exit(1)
             if self.args.use_slaves:
-                print Colors.Bred('can not use slaves with interactive debugger')
+                print(Colors.Bred('can not use slaves with interactive debugger'))
                 sys.exit(1)
 
             self.args.no_output_catch = True
@@ -254,7 +254,7 @@ class RLTest:
             try:
                 shutil.rmtree(self.args.log_dir)
             except Exception as e:
-                print e
+                print(e)
 
         debugger = None
         if self.args.use_valgrind:
@@ -319,14 +319,14 @@ class RLTest:
         if needShutdown:
             self.currEnv.stop()
             if self.args.use_valgrind and self.currEnv and not self.currEnv.checkExitCode():
-                print Colors.Bred('\tvalgrind check failure')
+                print(Colors.Bred('\tvalgrind check failure'))
                 self.addFailure(self.currEnv.testName,
                                 ['<Valgrind Failure>'])
             self.currEnv = None
 
     def printException(self, err):
         msg = 'Unhandled exception: {}'.format(err)
-        print '\t' + Colors.Bred(msg)
+        print('\t' + Colors.Bred(msg))
         traceback.print_exc(file=sys.stdout)
 
     def addFailuresFromEnv(self, name, env):
@@ -394,7 +394,7 @@ class RLTest:
     def _runTest(self, test, numberOfAssertionFailed=0, prefix=''):
         msgPrefix = test.name
 
-        print Colors.Cyan(prefix + test.name)
+        print(Colors.Cyan(prefix + test.name))
 
         if len(inspect.getargspec(test.target).args) > 0 and not test.is_method:
             try:
@@ -451,16 +451,16 @@ class RLTest:
         return numFailed
 
     def printSkip(self):
-        print '\t' + Colors.Green('[SKIP]')
+        print('\t' + Colors.Green('[SKIP]'))
 
     def printFail(self):
-        print '\t' + Colors.Bred('[FAIL]')
+        print('\t' + Colors.Bred('[FAIL]'))
 
     def printError(self):
-        print '\t' + Colors.Yellow('[ERROR]')
+        print('\t' + Colors.Yellow('[ERROR]'))
 
     def printPass(self):
-        print '\t' + Colors.Green('[PASS]')
+        print('\t' + Colors.Green('[PASS]'))
 
     def envScopeGuard(self):
         return EnvScopeGuard(self)
@@ -481,8 +481,8 @@ class RLTest:
         done = 0
         startTime = time.time()
         if self.args.interactive_debugger and len(self.loader.tests) != 1:
-            print self.tests
-            print Colors.Bred('only one test can be run on interactive-debugger use -t')
+            print(self.tests)
+            print(Colors.Bred('only one test can be run on interactive-debugger use -t'))
             sys.exit(1)
 
         for test in self.loader:
@@ -500,7 +500,7 @@ class RLTest:
                         self.addFailure(test.name + " [__init__]")
                         continue
 
-                    print Colors.Cyan(test.name)
+                    print(Colors.Cyan(test.name))
 
                     failures = 0
                     for subtest in test.get_functions(obj):
@@ -514,16 +514,16 @@ class RLTest:
         self.takeEnvDown(fullShutDown=True)
         endTime = time.time()
 
-        print Colors.Bold('Test Took: %d sec' % (endTime - startTime))
-        print Colors.Bold('Total Tests Run: %d, Total Tests Failed: %d, Total Tests Passed: %d' % (done, self.getTotalFailureCount(), done - self.getTotalFailureCount()))
+        print(Colors.Bold('Test Took: %d sec' % (endTime - startTime)))
+        print(Colors.Bold('Total Tests Run: %d, Total Tests Failed: %d, Total Tests Passed: %d' % (done, self.getTotalFailureCount(), done - self.getTotalFailureCount())))
         if self.testsFailed:
-            print Colors.Bold('Failed Tests Summary:')
+            print(Colors.Bold('Failed Tests Summary:'))
             for group, failures in self.testsFailed:
-                print '\t' + Colors.Bold(group)
+                print('\t' + Colors.Bold(group))
                 if not failures:
-                    print '\t\t' + Colors.Bred('Exception raised during test execution. See logs')
+                    print('\t\t' + Colors.Bred('Exception raised during test execution. See logs'))
                 for failure in failures:
-                    print '\t\t' + failure
+                    print('\t\t' + failure)
             sys.exit(1)
 
 

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -149,6 +149,10 @@ parser.add_argument(
     help='run env with slaves enabled')
 
 parser.add_argument(
+    '--decode-responses', action='store_const', const=True, default=False,
+    help='decode all responses from Redis to Unicode strings (utf-8)')
+
+parser.add_argument(
     '--shards-count', default=1, type=int,
     help='Number shards in bdb')
 
@@ -276,6 +280,7 @@ class RLTest:
         Env.defaultVerbose = self.args.verbose
         Env.defaultLogDir = self.args.log_dir
         Env.defaultUseSlaves = self.args.use_slaves
+        Env.defaultDecodeResponses = self.args.decode_responses
         Env.defaultShardsCount = self.args.shards_count
         Env.defaultProxyBinaryPath = self.args.proxy_binary_path
         Env.defaultEnterpriseRedisBinaryPath = self.args.enterprise_redis_path

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -120,11 +120,11 @@ class TestLoader(object):
 
     def print_tests(self):
         for t in self.tests:
-            print "Test: ", t.name
+            print("Test: ", t.name)
             if t.is_class:
-                print "\tClass"
-                print "\tFunctions"
+                print("\tClass")
+                print("\tFunctions")
                 for m in t.methnames:
-                    print "\t\t", m
+                    print("\t\t", m)
             else:
-                print "\tFunction"
+                print("\tFunction")

--- a/RLTest/redis_cluster.py
+++ b/RLTest/redis_cluster.py
@@ -23,14 +23,14 @@ class ClusterEnv(object):
             startPort += 2
 
     def printEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'info:')
-        print Colors.Yellow(prefix + '\tshards count:%d' % len(self.shards))
+        print(Colors.Yellow(prefix + 'info:'))
+        print(Colors.Yellow(prefix + '\tshards count:%d' % len(self.shards)))
         if self.modulePath:
-            print Colors.Yellow(prefix + '\tzip module path:%s' % self.modulePath)
+            print(Colors.Yellow(prefix + '\tzip module path:%s' % self.modulePath))
         if self.moduleArgs:
-            print Colors.Yellow(prefix + '\tmodule args:%s' % self.moduleArgs)
+            print(Colors.Yellow(prefix + '\tmodule args:%s' % self.moduleArgs))
         for i, shard in enumerate(self.shards):
-            print Colors.Yellow(prefix + 'shard: %d' % (i + 1))
+            print(Colors.Yellow(prefix + 'shard: %d' % (i + 1)))
             shard.printEnvData(prefix + '\t')
 
     def waitCluster(self, timeout_sec=40):

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -13,7 +13,7 @@ SLAVE = 2
 class StandardEnv(object):
     def __init__(self, redisBinaryPath, port=6379, modulePath=None, moduleArgs=None, outputFilesFormat=None,
                  dbDirPath=None, useSlaves=False, serverId=1, password=None, libPath=None, clusterEnabled=False,
-                 useAof=False, debugger=None, noCatch=False):
+                 useAof=False, debugger=None, noCatch=False, decode_responses=False):
         self.redisBinaryPath = os.path.expanduser(redisBinaryPath) if redisBinaryPath.startswith('~/') else redisBinaryPath
         self.port = port
         self.modulePath = os.path.abspath(modulePath) if modulePath is not None else None
@@ -29,6 +29,7 @@ class StandardEnv(object):
         self.debugger = debugger
         self.noCatch = noCatch
         self.environ = os.environ.copy()
+        self.decode_responses = decode_responses
 
         if self.has_interactive_debugger:
             assert self.noCatch and not self.useSlaves and not self.clusterEnabled
@@ -110,28 +111,28 @@ class StandardEnv(object):
         return self.masterServerId if role == MASTER else self.slaveServerId
 
     def _printEnvData(self, prefix='', role=MASTER):
-        print Colors.Yellow(prefix + 'pid: %d' % (self.getPid(role)))
-        print Colors.Yellow(prefix + 'port: %d' % (self.getPort(role)))
-        print Colors.Yellow(prefix + 'binary path: %s' % (self.redisBinaryPath))
-        print Colors.Yellow(prefix + 'server id: %d' % (self.getServerId(role)))
-        print Colors.Yellow(prefix + 'using debugger: {}'.format(bool(self.debugger)))
+        print(Colors.Yellow(prefix + 'pid: %d' % (self.getPid(role))))
+        print(Colors.Yellow(prefix + 'port: %d' % (self.getPort(role))))
+        print(Colors.Yellow(prefix + 'binary path: %s' % (self.redisBinaryPath)))
+        print(Colors.Yellow(prefix + 'server id: %d' % (self.getServerId(role))))
+        print(Colors.Yellow(prefix + 'using debugger: {}'.format(bool(self.debugger))))
         if self.modulePath:
-            print Colors.Yellow(prefix + 'module: %s' % (self.modulePath))
+            print(Colors.Yellow(prefix + 'module: %s' % (self.modulePath)))
             if self.moduleArgs:
-                print Colors.Yellow(prefix + 'module args: %s' % (self.moduleArgs))
+                print(Colors.Yellow(prefix + 'module args: %s' % (self.moduleArgs)))
         if self.outputFilesFormat:
-            print Colors.Yellow(prefix + 'log file: %s' % (self._getFileName(role, '.log')))
-            print Colors.Yellow(prefix + 'db file name: %s' % self._getFileName(role, '.rdb'))
+            print(Colors.Yellow(prefix + 'log file: %s' % (self._getFileName(role, '.log'))))
+            print(Colors.Yellow(prefix + 'db file name: %s' % self._getFileName(role, '.rdb')))
         if self.dbDirPath:
-            print Colors.Yellow(prefix + 'db dir path: %s' % (self.dbDirPath))
+            print(Colors.Yellow(prefix + 'db dir path: %s' % (self.dbDirPath)))
         if self.libPath:
-            print Colors.Yellow(prefix + 'library path: %s' % (self.libPath))
+            print(Colors.Yellow(prefix + 'library path: %s' % (self.libPath)))
 
     def printEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'master:')
+        print(Colors.Yellow(prefix + 'master:'))
         self._printEnvData(prefix + '\t', MASTER)
         if self.useSlaves:
-            print Colors.Yellow(prefix + 'slave:')
+            print(Colors.Yellow(prefix + 'slave:'))
             self._printEnvData(prefix + '\t', SLAVE)
 
     def startEnv(self):
@@ -174,7 +175,7 @@ class StandardEnv(object):
         if not self._isAlive(process):
             if not self.has_interactive_debugger:
                 # on interactive debugger its expected that then process will not be alive
-                print '\t' + Colors.Bred('process is not alive, might have crash durring test execution, check this out. server id : %s' % str(serverId))
+                print('\t' + Colors.Bred('process is not alive, might have crash during test execution, check this out. server id : %s' % str(serverId)))
             return
         try:
             process.terminate()
@@ -196,11 +197,11 @@ class StandardEnv(object):
         self.envIsUp = False
 
     def getConnection(self):
-        return redis.Redis('localhost', self.port, password=self.password)
+        return redis.Redis('localhost', self.port, password=self.password, decode_responses=self.decode_responses)
 
     def getSlaveConnection(self):
         if self.useSlaves:
-            return redis.Redis('localhost', self.getSlavePort(), password=self.password)
+            return redis.Redis('localhost', self.getSlavePort(), password=self.password, decode_responses=self.decode_responses)
         raise Exception('asked for slave connection but no slave exists')
 
     def flush(self):
@@ -239,15 +240,15 @@ class StandardEnv(object):
         try:
             self.getConnection().execute_command(*cmd)
         except Exception as e:
-            print e
+            print(e)
 
     def checkExitCode(self):
         ret = True
         if self.masterExitCode != 0:
-            print '\t' + Colors.Bred('bad exit code for serverId %s' % str(self.masterServerId))
+            print('\t' + Colors.Bred('bad exit code for serverId %s' % str(self.masterServerId)))
             ret = False
         if self.useSlaves and self.slaveExitCode != 0:
-            print '\t' + Colors.Bred('bad exit code for serverId %s' % str(self.slaveServerId))
+            print('\t' + Colors.Bred('bad exit code for serverId %s' % str(self.slaveServerId)))
             ret = False
         return ret
 


### PR DESCRIPTION
Resolves several classes of errors throughout RLTest
related to differences between python major versions:
- SyntaxError: Missing parentheses in call to 'print'. Did you mean print('print')?
- ModuleNotFoundError: No module named 'RLTest'
- ModuleNotFoundError: No module named 'EnterpriseClusterEnv'
- ModuleNotFoundError: No module named 'CcsMock'
- ModuleNotFoundError: No module named 'Dmc'
- TypeError: 'mappingproxy' object does not support item assignment

Additionally, decoding of results from the Redis python
module is automatically performed by default on python3
but can be optionally disabled by tests.