### PR TITLE
Add `getConnectionArgs` for multiprocessing tests + python 3 fixes

### DIFF
--- a/RLTest/Enterprise/CcsMock.py
+++ b/RLTest/Enterprise/CcsMock.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 import subprocess
 import redis
 import os
-from RLTest.utils import wait_for_conn, Colors
+from ..utils import wait_for_conn, Colors
 
 
 class CcsMock():
@@ -40,15 +41,15 @@ class CcsMock():
             self.process = None
 
     def PrintEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'pid: %d' % self.process.pid)
-        print Colors.Yellow(prefix + 'unix socket: %s' % self.CCS_UNIX_SOCKET_DEFAULT_PATH)
-        print Colors.Yellow(prefix + 'binary path: %s' % self.redisBinaryPath)
+        print(Colors.Yellow(prefix + 'pid: %d' % self.process.pid))
+        print(Colors.Yellow(prefix + 'unix socket: %s' % self.CCS_UNIX_SOCKET_DEFAULT_PATH))
+        print(Colors.Yellow(prefix + 'binary path: %s' % self.redisBinaryPath))
         if self.directory:
-            print Colors.Yellow(prefix + 'db dir path: %s' % (self.directory))
-        print Colors.Yellow(prefix + 'rdb file name: %s' % (self.CCS_DB_RDB_FILE_NAME))
-        print Colors.Yellow(prefix + 'log file name: %s' % (self.CCS_LOG_FILE_NAME))
+            print(Colors.Yellow(prefix + 'db dir path: %s' % (self.directory)))
+        print(Colors.Yellow(prefix + 'rdb file name: %s' % (self.CCS_DB_RDB_FILE_NAME)))
+        print(Colors.Yellow(prefix + 'log file name: %s' % (self.CCS_LOG_FILE_NAME)))
         if self.libPath:
-            print Colors.Yellow(prefix + 'lib path: %s' % (self.libPath))
+            print(Colors.Yellow(prefix + 'lib path: %s' % (self.libPath)))
 
     def setup(self, shards, bdb_fields=None, endpoint_ccs_params=None, legacy_hash_slots=True, extra_keys=None):
 

--- a/RLTest/Enterprise/Dmc.py
+++ b/RLTest/Enterprise/Dmc.py
@@ -1,7 +1,7 @@
 import os
 import psutil
 import subprocess
-from RLTest.utils import Colors
+from ..utils import Colors
 
 
 class Dmc():
@@ -37,9 +37,9 @@ class Dmc():
         self.process = None
 
     def PrintEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'dmc binary path: %s' % self.dmcBinaryPath)
-        print Colors.Yellow(prefix + 'dmc env: %s' % str(self.env))
-        print Colors.Yellow(prefix + 'dir path: %s' % str(self.directory))
-        print Colors.Yellow(prefix + 'log file name: %s' % str(self.DMC_LOG_FILE_NAME))
+        print(Colors.Yellow(prefix + 'dmc binary path: %s' % self.dmcBinaryPath))
+        print(Colors.Yellow(prefix + 'dmc env: %s' % str(self.env)))
+        print(Colors.Yellow(prefix + 'dir path: %s' % str(self.directory)))
+        print(Colors.Yellow(prefix + 'log file name: %s' % str(self.DMC_LOG_FILE_NAME)))
         if self.libPath:
-            print Colors.Yellow(prefix + 'lib path: %s' % str(self.libPath))
+            print(Colors.Yellow(prefix + 'lib path: %s' % str(self.libPath)))

--- a/RLTest/Enterprise/EnterpriseClusterEnv.py
+++ b/RLTest/Enterprise/EnterpriseClusterEnv.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from ..redis_std import StandardEnv
+from ..redis_std import StandardEnv, get_decode_responses
 from ..utils import Colors, wait_for_conn
 from .CcsMock import CcsMock
 from .Dmc import Dmc
@@ -111,10 +111,11 @@ class EnterpriseClusterEnv():
         self.dmc.Stop()
         self.envIsUp = False
 
-    def getConnection(self, decode_responses=True):
-        return redis.Redis('localhost', self.DMC_PORT, decode_responses=decode_responses)
+    def getConnection(self, decode_responses=None):
+        do_decode = get_decode_responses(decode_responses)
+        return redis.Redis('localhost', self.DMC_PORT, decode_responses=do_decode)
 
-    def getSlaveConnection(self, decode_responses=True):
+    def getSlaveConnection(self, decode_responses=None):
         raise Exception('unsupported')
 
     def flush(self):

--- a/RLTest/Enterprise/EnterpriseClusterEnv.py
+++ b/RLTest/Enterprise/EnterpriseClusterEnv.py
@@ -1,7 +1,8 @@
-from RLTest.redis_std import StandardEnv
-from RLTest.utils import Colors, wait_for_conn
-from CcsMock import CcsMock
-from Dmc import Dmc
+from __future__ import print_function
+from ..redis_std import StandardEnv
+from ..utils import Colors, wait_for_conn
+from .CcsMock import CcsMock
+from .Dmc import Dmc
 import redis
 import os
 import json
@@ -60,21 +61,21 @@ class EnterpriseClusterEnv():
                 self.moduleArgs = self.moduleConfig['command_line_args']
 
     def printEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'bdb info:')
-        print Colors.Yellow(prefix + '\tlistening port:%d' % self.DMC_PORT)
-        print Colors.Yellow(prefix + '\tshards count:%d' % len(self.shards))
+        print(Colors.Yellow(prefix + 'bdb info:'))
+        print(Colors.Yellow(prefix + '\tlistening port:%d' % self.DMC_PORT))
+        print(Colors.Yellow(prefix + '\tshards count:%d' % len(self.shards)))
         if self.modulePath:
-            print Colors.Yellow(prefix + '\tzip module path:%s' % self.modulePath)
+            print(Colors.Yellow(prefix + '\tzip module path:%s' % self.modulePath))
         if self.moduleSoFilePath:
-            print Colors.Yellow(prefix + '\tso module path:%s' % self.moduleSoFilePath)
+            print(Colors.Yellow(prefix + '\tso module path:%s' % self.moduleSoFilePath))
         if self.moduleArgs:
-            print Colors.Yellow(prefix + '\tmodule args:%s' % self.moduleArgs)
+            print(Colors.Yellow(prefix + '\tmodule args:%s' % self.moduleArgs))
         for i, shard in enumerate(self.shards):
-            print Colors.Yellow(prefix + 'shard: %d' % (i + 1))
+            print(Colors.Yellow(prefix + 'shard: %d' % (i + 1)))
             shard.printEnvData(prefix + '\t')
-        print Colors.Yellow(prefix + 'ccs:')
+        print(Colors.Yellow(prefix + 'ccs:'))
         self.ccs.PrintEnvData(prefix + '\t')
-        print Colors.Yellow(prefix + 'dmc:')
+        print(Colors.Yellow(prefix + 'dmc:'))
         self.dmc.PrintEnvData(prefix + '\t')
 
     def startEnv(self):

--- a/RLTest/Enterprise/EnterpriseClusterEnv.py
+++ b/RLTest/Enterprise/EnterpriseClusterEnv.py
@@ -111,10 +111,10 @@ class EnterpriseClusterEnv():
         self.dmc.Stop()
         self.envIsUp = False
 
-    def getConnection(self):
-        return redis.Redis('localhost', self.DMC_PORT)
+    def getConnection(self, decode_responses=True):
+        return redis.Redis('localhost', self.DMC_PORT, decode_responses=decode_responses)
 
-    def getSlaveConnection(self):
+    def getSlaveConnection(self, decode_responses=True):
         raise Exception('unsupported')
 
     def flush(self):

--- a/RLTest/Enterprise/__init__.py
+++ b/RLTest/Enterprise/__init__.py
@@ -1,4 +1,4 @@
-from EnterpriseClusterEnv import EnterpriseClusterEnv
+from .EnterpriseClusterEnv import EnterpriseClusterEnv
 
 __all__ = [
     'EnterpriseClusterEnv'

--- a/RLTest/Enterprise/binaryrepo.py
+++ b/RLTest/Enterprise/binaryrepo.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import os.path
 import shutil
 import platform
 import subprocess
 import sys
 
-from RLTest.utils import Colors
+from ..utils import Colors
 
 
 OS_NAME = platform.dist()[2]
@@ -31,15 +32,15 @@ class BinaryRepository(object):
         self.debname = debname
 
     def download_binaries(self, binariesName='binaries.tar'):
-        print Colors.Yellow('installing enterprise binaries')
-        print Colors.Yellow('creating RLTest working dir: %s' % self.root)
+        print(Colors.Yellow('installing enterprise binaries'))
+        print(Colors.Yellow('creating RLTest working dir: %s' % self.root))
         try:
             shutil.rmtree(self.root)
             os.makedirs(self.root)
         except Exception:
             pass
 
-        print Colors.Yellow('download binaries')
+        print(Colors.Yellow('download binaries'))
         args = ['wget', self.url, '-O', os.path.join(self.root, binariesName)]
         process = subprocess.Popen(args=args, stdout=sys.stdout,
                                         stderr=sys.stdout)
@@ -47,7 +48,7 @@ class BinaryRepository(object):
         if process.poll() != 0:
             raise Exception('failed to download enterprise binaries from s3')
 
-        print Colors.Yellow('extracting binaries')
+        print(Colors.Yellow('extracting binaries'))
 
         args = ['tar', '-xvf', os.path.join(self.root, binariesName),
                 '--directory', self.root, self.debname]
@@ -67,4 +68,4 @@ class BinaryRepository(object):
             raise Exception(
                 'failed to extract binaries to %s' % self.self.root)
 
-        print Colors.Yellow('finished installing enterprise binaries')
+        print(Colors.Yellow('finished installing enterprise binaries'))

--- a/RLTest/__init__.py
+++ b/RLTest/__init__.py
@@ -1,5 +1,5 @@
-from RLTest.env import Env
-from RLTest.redis_std import StandardEnv
+from .env import Env
+from .redis_std import StandardEnv
 
 __all__ = [
     'Env',

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -215,11 +215,14 @@ class Env:
     def getEnvStr(self):
         return self.env
 
-    def getConnection(self):
-        return self.envRunner.getConnection()
+    def getConnection(self, decode_responses=True):
+        return self.envRunner.getConnection(decode_responses=decode_responses)
 
-    def getSlaveConnection(self):
-        return self.envRunner.getSlaveConnection()
+    def getConnectionArgs(self, decode_responses=True):
+        return self.envRunner.getConnectionArgs(decode_responses=decode_responses)
+
+    def getSlaveConnection(self, decode_responses=True):
+        return self.envRunner.getSlaveConnection(decode_responses=decode_responses)
 
     def flush(self):
         self.envRunner.flush()

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import print_function
 import os
 import sys
 import redis
@@ -6,10 +7,10 @@ import unittest
 import inspect
 import contextlib
 import warnings
-from redis_std import StandardEnv
-from redis_cluster import ClusterEnv
-from utils import Colors
-from Enterprise.EnterpriseClusterEnv import EnterpriseClusterEnv
+from .redis_std import StandardEnv
+from .redis_cluster import ClusterEnv
+from .utils import Colors
+from .Enterprise.EnterpriseClusterEnv import EnterpriseClusterEnv
 
 
 class TestAssertionFailure(Exception):
@@ -20,7 +21,7 @@ def addDeprecatedMethod(cls, name, invoke):
     def method(*argc, **nargs):
         warnings.warn('%s is deprecated, use %s instead' % (str(name), str(invoke)), DeprecationWarning)
         return invoke(*argc, **nargs)
-    cls.__dict__[name] = method
+    setattr(cls, name, method)
 
 
 class Query:
@@ -39,12 +40,12 @@ class Query:
 
     def _prettyPrint(self, result, prefix='\t'):
         if type(result) is list:
-            print prefix + '['
+            print(prefix + '[')
             for r in result:
                 self._prettyPrint(r, prefix + '\t')
-            print prefix + ']'
+            print(prefix + ']')
             return
-        print prefix + str(result)
+        print(prefix + str(result))
 
     def prettyPrint(self):
         self._prettyPrint(self.res)
@@ -138,7 +139,7 @@ class Env:
         self.testName = self.testName.replace(' ', '_')
 
         if testDescription:
-            print Colors.Gray('\tdescription: ' + testDescription)
+            print(Colors.Gray('\tdescription: ' + testDescription))
 
         self.module = module if module else Env.defaultModule
         self.moduleArgs = moduleArgs if moduleArgs else Env.defaultModuleArgs
@@ -151,10 +152,10 @@ class Env:
 
         self.assertionFailedSummary = []
 
-        if Env.RTestInstance.currEnv and self.compareEnvs(Env.RTestInstance.currEnv):
+        if Env.RTestInstance and Env.RTestInstance.currEnv and self.compareEnvs(Env.RTestInstance.currEnv):
             self.envRunner = Env.RTestInstance.currEnv.envRunner
         else:
-            if Env.RTestInstance.currEnv:
+            if Env.RTestInstance and Env.RTestInstance.currEnv:
                 Env.RTestInstance.currEnv.stop()
             self.envRunner = self.getEnvByName()
 
@@ -165,7 +166,7 @@ class Env:
 
         self.start()
         if self.verbose >= 2:
-            print Colors.Blue('\tenv data:')
+            print(Colors.Blue('\tenv data:'))
             self.envRunner.printEnvData('\t\t')
 
         Env.RTestInstance.currEnv = self
@@ -239,10 +240,10 @@ class Env:
     def _assertion(self, checkStr, trueValue, depth=0):
         basemsg = Colors.Yellow(checkStr) + '\t' + Colors.Gray(self._getCallerPosition(3 + depth))
         if trueValue and self.verbose:
-            print '\t' + Colors.Green('✅  (OK):\t') + basemsg
+            print('\t' + Colors.Green('✅  (OK):\t') + basemsg)
         elif not trueValue:
             failureSummary = Colors.Bred('❌  (FAIL):\t') + basemsg
-            print '\t' + failureSummary
+            print('\t' + failureSummary)
             if self.defaultExitOnFailure:
                 raise TestAssertionFailure('Assertion Failed!')
 
@@ -267,10 +268,10 @@ class Env:
         self.assertEqual(val, False, depth + 1)
 
     def assertContains(self, value, holder, depth=0):
-        self._assertion('%s should contains %s' % (str(holder), str(value)), value in holder, depth)
+        self._assertion('%s should contain %s' % (str(holder), str(value)), value in holder, depth)
 
     def assertNotContains(self, value, holder, depth=0):
-        self._assertion('%s should not contains %s' % (str(holder), str(value)), value not in holder, depth)
+        self._assertion('%s should not contain %s' % (str(holder), str(value)), value not in holder, depth)
 
     def assertGreaterEqual(self, value1, value2, depth=0):
         self._assertion('%s >= %s' % (str(value1), str(value2)), value1 >= value2, depth)
@@ -369,7 +370,7 @@ class Env:
 
     def debugPrint(self, msg, force=False):
         if Env.defaultDebugPrints or force:
-            print '\t' + Colors.Bold('debug:\t') + Colors.Gray(msg)
+            print('\t' + Colors.Bold('debug:\t') + Colors.Gray(msg))
 
     def checkExitCode(self):
         return self.envRunner.checkExitCode()

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import imp
@@ -121,11 +122,11 @@ class TestLoader(object):
 
     def print_tests(self):
         for t in self.tests:
-            print "Test: ", t.name
+            print("Test: ", t.name)
             if t.is_class:
-                print "\tClass"
-                print "\tFunctions"
+                print("\tClass")
+                print("\tFunctions")
                 for m in t.methnames:
-                    print "\t\t", m
+                    print("\t\t", m)
             else:
-                print "\tFunction"
+                print("\tFunction")

--- a/RLTest/redis_cluster.py
+++ b/RLTest/redis_cluster.py
@@ -1,8 +1,9 @@
-from redis_std import StandardEnv
+from __future__ import print_function
+from .redis_std import StandardEnv
 import redis
 import rediscluster
 import time
-from RLTest.utils import Colors
+from .utils import Colors
 
 
 class ClusterEnv(object):
@@ -23,14 +24,14 @@ class ClusterEnv(object):
             startPort += 2
 
     def printEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'info:')
-        print Colors.Yellow(prefix + '\tshards count:%d' % len(self.shards))
+        print(Colors.Yellow(prefix + 'info:'))
+        print(Colors.Yellow(prefix + '\tshards count:%d' % len(self.shards)))
         if self.modulePath:
-            print Colors.Yellow(prefix + '\tzip module path:%s' % self.modulePath)
+            print(Colors.Yellow(prefix + '\tzip module path:%s' % self.modulePath))
         if self.moduleArgs:
-            print Colors.Yellow(prefix + '\tmodule args:%s' % self.moduleArgs)
+            print(Colors.Yellow(prefix + '\tmodule args:%s' % self.moduleArgs))
         for i, shard in enumerate(self.shards):
-            print Colors.Yellow(prefix + 'shard: %d' % (i + 1))
+            print(Colors.Yellow(prefix + 'shard: %d' % (i + 1)))
             shard.printEnvData(prefix + '\t')
 
     def waitCluster(self, timeout_sec=40):

--- a/RLTest/redis_cluster.py
+++ b/RLTest/redis_cluster.py
@@ -87,14 +87,14 @@ class ClusterEnv(object):
             shard.stopEnv()
         self.envIsUp = False
 
-    def getConnection(self):
-        return self.shards[0].getConnection()
+    def getConnection(self, decode_responses=True):
+        return self.shards[0].getConnection(decode_responses=decode_responses)
 
-    def getClusterConnection(self):
+    def getClusterConnection(self, decode_responses=True):
         return rediscluster.StrictRedisCluster(startup_nodes=[{'host': 'localhost', 'port': self.shards[0].getMasterPort()}],
-                                               decode_responses=True)
+                                               decode_responses=decode_responses)
 
-    def getSlaveConnection(self):
+    def getSlaveConnection(self, decode_responses=True):
         raise Exception('unsupported')
 
     def flush(self):

--- a/RLTest/redis_cluster.py
+++ b/RLTest/redis_cluster.py
@@ -87,14 +87,15 @@ class ClusterEnv(object):
             shard.stopEnv()
         self.envIsUp = False
 
-    def getConnection(self, decode_responses=True):
+    def getConnection(self, decode_responses=None):
         return self.shards[0].getConnection(decode_responses=decode_responses)
 
-    def getClusterConnection(self, decode_responses=True):
+    def getClusterConnection(self, decode_responses=None):
+        do_decode = get_decode_responses(decode_responses)
         return rediscluster.StrictRedisCluster(startup_nodes=[{'host': 'localhost', 'port': self.shards[0].getMasterPort()}],
-                                               decode_responses=decode_responses)
+                                               decode_responses=do_decode)
 
-    def getSlaveConnection(self, decode_responses=True):
+    def getSlaveConnection(self, decode_responses=None):
         raise Exception('unsupported')
 
     def flush(self):

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -9,6 +9,11 @@ from .utils import Colors, wait_for_conn
 
 MASTER = 1
 SLAVE = 2
+DECODE_DEFAULT = sys.version_info[0] == 3
+
+
+def get_decode_responses(decode_responses):
+    return DECODE_DEFAULT if decode_responses is None else decode_responses
 
 
 class StandardEnv(object):
@@ -196,20 +201,23 @@ class StandardEnv(object):
             self.slaveProcess = None
         self.envIsUp = False
 
-    def getConnection(self, decode_responses=True):
-        return redis.Redis('localhost', self.port, password=self.password, decode_responses=decode_responses)
+    def getConnection(self, decode_responses=None):
+        do_decode = get_decode_responses(decode_responses)
+        return redis.Redis('localhost', self.port, password=self.password, decode_responses=do_decode)
 
-    def getConnectionArgs(self, decode_responses=True):
+    def getConnectionArgs(self, decode_responses=None):
+        do_decode = get_decode_responses(decode_responses)
         return {
             'host': 'localhost',
             'port': self.port,
             'password': self.password,
-            'decode_responses': decode_responses
+            'decode_responses': do_decode
         }
 
-    def getSlaveConnection(self, decode_responses=True):
+    def getSlaveConnection(self, decode_responses=None):
         if self.useSlaves:
-            return redis.Redis('localhost', self.getSlavePort(), password=self.password, decode_responses=decode_responses)
+            do_decode = get_decode_responses(decode_responses)
+            return redis.Redis('localhost', self.getSlavePort(), password=self.password, decode_responses=do_decode)
         raise Exception('asked for slave connection but no slave exists')
 
     def flush(self):

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -1,9 +1,10 @@
+from __future__ import print_function
 import redis
 import subprocess
 import sys
 import os
 import platform
-from utils import Colors, wait_for_conn
+from .utils import Colors, wait_for_conn
 
 
 MASTER = 1
@@ -110,28 +111,28 @@ class StandardEnv(object):
         return self.masterServerId if role == MASTER else self.slaveServerId
 
     def _printEnvData(self, prefix='', role=MASTER):
-        print Colors.Yellow(prefix + 'pid: %d' % (self.getPid(role)))
-        print Colors.Yellow(prefix + 'port: %d' % (self.getPort(role)))
-        print Colors.Yellow(prefix + 'binary path: %s' % (self.redisBinaryPath))
-        print Colors.Yellow(prefix + 'server id: %d' % (self.getServerId(role)))
-        print Colors.Yellow(prefix + 'using debugger: {}'.format(bool(self.debugger)))
+        print(Colors.Yellow(prefix + 'pid: %d' % (self.getPid(role))))
+        print(Colors.Yellow(prefix + 'port: %d' % (self.getPort(role))))
+        print(Colors.Yellow(prefix + 'binary path: %s' % (self.redisBinaryPath)))
+        print(Colors.Yellow(prefix + 'server id: %d' % (self.getServerId(role))))
+        print(Colors.Yellow(prefix + 'using debugger: {}'.format(bool(self.debugger))))
         if self.modulePath:
-            print Colors.Yellow(prefix + 'module: %s' % (self.modulePath))
+            print(Colors.Yellow(prefix + 'module: %s' % (self.modulePath)))
             if self.moduleArgs:
-                print Colors.Yellow(prefix + 'module args: %s' % (self.moduleArgs))
+                print(Colors.Yellow(prefix + 'module args: %s' % (self.moduleArgs)))
         if self.outputFilesFormat:
-            print Colors.Yellow(prefix + 'log file: %s' % (self._getFileName(role, '.log')))
-            print Colors.Yellow(prefix + 'db file name: %s' % self._getFileName(role, '.rdb'))
+            print(Colors.Yellow(prefix + 'log file: %s' % (self._getFileName(role, '.log'))))
+            print(Colors.Yellow(prefix + 'db file name: %s' % self._getFileName(role, '.rdb')))
         if self.dbDirPath:
-            print Colors.Yellow(prefix + 'db dir path: %s' % (self.dbDirPath))
+            print(Colors.Yellow(prefix + 'db dir path: %s' % (self.dbDirPath)))
         if self.libPath:
-            print Colors.Yellow(prefix + 'library path: %s' % (self.libPath))
+            print(Colors.Yellow(prefix + 'library path: %s' % (self.libPath)))
 
     def printEnvData(self, prefix=''):
-        print Colors.Yellow(prefix + 'master:')
+        print(Colors.Yellow(prefix + 'master:'))
         self._printEnvData(prefix + '\t', MASTER)
         if self.useSlaves:
-            print Colors.Yellow(prefix + 'slave:')
+            print(Colors.Yellow(prefix + 'slave:'))
             self._printEnvData(prefix + '\t', SLAVE)
 
     def startEnv(self):
@@ -174,7 +175,7 @@ class StandardEnv(object):
         if not self._isAlive(process):
             if not self.has_interactive_debugger:
                 # on interactive debugger its expected that then process will not be alive
-                print '\t' + Colors.Bred('process is not alive, might have crash durring test execution, check this out. server id : %s' % str(serverId))
+                print('\t' + Colors.Bred('process is not alive, might have crash durring test execution, check this out. server id : %s' % str(serverId)))
             return
         try:
             process.terminate()
@@ -196,11 +197,11 @@ class StandardEnv(object):
         self.envIsUp = False
 
     def getConnection(self):
-        return redis.Redis('localhost', self.port, password=self.password)
+        return redis.Redis('localhost', self.port, password=self.password, decode_responses=True)
 
     def getSlaveConnection(self):
         if self.useSlaves:
-            return redis.Redis('localhost', self.getSlavePort(), password=self.password)
+            return redis.Redis('localhost', self.getSlavePort(), password=self.password, decode_responses=True)
         raise Exception('asked for slave connection but no slave exists')
 
     def flush(self):
@@ -239,15 +240,15 @@ class StandardEnv(object):
         try:
             self.getConnection().execute_command(*cmd)
         except Exception as e:
-            print e
+            print(e)
 
     def checkExitCode(self):
         ret = True
         if self.masterExitCode != 0:
-            print '\t' + Colors.Bred('bad exit code for serverId %s' % str(self.masterServerId))
+            print('\t' + Colors.Bred('bad exit code for serverId %s' % str(self.masterServerId)))
             ret = False
         if self.useSlaves and self.slaveExitCode != 0:
-            print '\t' + Colors.Bred('bad exit code for serverId %s' % str(self.slaveServerId))
+            print('\t' + Colors.Bred('bad exit code for serverId %s' % str(self.slaveServerId)))
             ret = False
         return ret
 

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -175,7 +175,7 @@ class StandardEnv(object):
         if not self._isAlive(process):
             if not self.has_interactive_debugger:
                 # on interactive debugger its expected that then process will not be alive
-                print('\t' + Colors.Bred('process is not alive, might have crash durring test execution, check this out. server id : %s' % str(serverId)))
+                print('\t' + Colors.Bred('process is not alive, might have crashed during test execution, check this out. server id : %s' % str(serverId)))
             return
         try:
             process.terminate()
@@ -196,12 +196,20 @@ class StandardEnv(object):
             self.slaveProcess = None
         self.envIsUp = False
 
-    def getConnection(self):
-        return redis.Redis('localhost', self.port, password=self.password, decode_responses=True)
+    def getConnection(self, decode_responses=True):
+        return redis.Redis('localhost', self.port, password=self.password, decode_responses=decode_responses)
 
-    def getSlaveConnection(self):
+    def getConnectionArgs(self, decode_responses=True):
+        return {
+            'host': 'localhost',
+            'port': self.port,
+            'password': self.password,
+            'decode_responses': decode_responses
+        }
+
+    def getSlaveConnection(self, decode_responses=True):
         if self.useSlaves:
-            return redis.Redis('localhost', self.getSlavePort(), password=self.password, decode_responses=True)
+            return redis.Redis('localhost', self.getSlavePort(), password=self.password, decode_responses=decode_responses)
         raise Exception('asked for slave connection but no slave exists')
 
     def flush(self):

--- a/RLTest/utils.py
+++ b/RLTest/utils.py
@@ -4,14 +4,15 @@ import time
 
 def wait_for_conn(conn, retries=20, command='PING', shouldBe=True):
     """Wait until a given Redis connection is ready"""
+    err = None
     while retries > 0:
         try:
             if conn.execute_command(command) == shouldBe:
                 return conn
         except redis.exceptions.BusyLoadingError:
             time.sleep(0.1)  # give extra 100msec in case of RDB loading
-        except redis.ConnectionError as err:
-            pass
+        except redis.ConnectionError as e:
+            err = e
         time.sleep(0.1)
         retries -= 1
     raise Exception('Cannot establish connection %s: %s' % (conn, err))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-redis>=2.10.5
+# redis>=2.10.5
 redis-py-cluster
 psutil

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     version='0.1',
     packages=find_packages(),
     install_requires=[
-        'redis>=2.10.5',
+        # 'redis>=2.10.5',
         'redis-py-cluster',
         'psutil'
     ],


### PR DESCRIPTION
This PR adds a method to `env` to support getting connection arguments, rather than the actual connection, from an `env`. This is useful when a part of a test needs to run in a multiprocessing process, since `env` itself and the connection obtained with `env.getConnection` are both not serializable.

With this new method it's easy to leverage on multiprocessing in tests to test concurrency, as in:

```
def run_test_multiproc(env, n_procs, fn, args=()):
    pool = Pool(processes=n_procs)
    for _ in range(n_procs):
        pool.apply_async(fn, args = (env.getConnectionArgs(), *args))
    pool.close()
    pool.join()

def example_multiproc_fn(connArgs):
    con = redis.Redis(**connArgs)
    con.set('x', 1)

def test_example_multiproc():
    env = Env(testDescription="Basic multiprocessing test")
    run_test_multiproc(env, 10, example_multiproc_fn)
    con = env.getConnection()
    env.assertEqual(con.get('x'), '1')
```

This PR also adds the necessary fixes for Python3. This includes a new `decode_response` argument  to `getConnection`, defaulting to `True`.

**DISCLAIMER**: I know there is another PR that adds Python3 support to RLTest and I've seen there's an ongoing discussion on copyright. I haven't looked at that code, I just needed Python3 support to continue my work so I went in and added it. Frankly I'm not sure how to handle this situation gracefully.