### PR TITLE
Fix: local variable 'err' referenced before assignment

### DIFF
--- a/RLTest/utils.py
+++ b/RLTest/utils.py
@@ -4,6 +4,7 @@ import time
 
 def wait_for_conn(conn, retries=20, command='PING', shouldBe=True):
     """Wait until a given Redis connection is ready"""
+    err1 = ''
     while retries > 0:
         try:
             if conn.execute_command(command) == shouldBe:
@@ -11,10 +12,10 @@ def wait_for_conn(conn, retries=20, command='PING', shouldBe=True):
         except redis.exceptions.BusyLoadingError:
             time.sleep(0.1)  # give extra 100msec in case of RDB loading
         except redis.ConnectionError as err:
-            pass
+            err1 = str(err)
         time.sleep(0.1)
         retries -= 1
-    raise Exception('Cannot establish connection %s: %s' % (conn, err))
+    raise Exception('Cannot establish connection %s: %s' % (conn, err1))
 
 
 class Colors(object):


### PR DESCRIPTION
File "/home/circleci/project/venv/lib/python3.6/site-packages/RLTest/utils.py", line 17, in wait_for_conn
  raise Exception('Cannot establish connection %s: %s' % (conn, err))
UnboundLocalError: local variable 'err' referenced before assignment