### PR TITLE
LD_LIBRARY_PATH: append rather than override

### DIFF
--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -39,7 +39,7 @@ class StandardEnv(object):
         else:
             self.libPath = None
         if self.libPath:
-            self.environ['LD_LIBRARY_PATH'] = self.libPath
+            self.environ['LD_LIBRARY_PATH'] = self.libPath + ":" + self.environ['LD_LIBRARY_PATH']
 
         self.masterCmdArgs = self.createCmdArgs(MASTER)
         if self.useSlaves:


### PR DESCRIPTION
Overriding LD_LIBRARY_PATH prevents user from setting his own.