### PR TITLE
Clean up all cluster processes on shutdown

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -352,6 +352,7 @@ class RLTest:
                 self.currEnv.flush()
                 needShutdown = False
             except Exception as e:
+                self.currEnv.stop()
                 self.handleFailure(exception=e, testname='[env dtor]',
                                    env=self.currEnv)
 


### PR DESCRIPTION
If a cluster node crashes, don't crash again in trying to flush all the
nodes. Ensure all child processes are killed