### PR TITLE
Fixed python3.8 issue with platform package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
  push:
  pull_request:
- schedule:
-  - cron: "0 0 * * *"
 
 jobs:
   build-ubuntu:
@@ -13,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, ubuntu-16.04]
-        python: ['2.7', '3.6']
+        python: ['2.7', '3.6', '3.8' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
  push:
  pull_request:
+ schedule:
+  - cron: "0 0 * * *"
 
 jobs:
   build-ubuntu:

--- a/RLTest/Enterprise/binaryrepo.py
+++ b/RLTest/Enterprise/binaryrepo.py
@@ -1,14 +1,14 @@
 from __future__ import print_function
 import os.path
 import shutil
-import platform
+import distro
 import subprocess
 import sys
 
 from RLTest.utils import Colors
 
 
-OS_NAME = platform.dist()[2]
+OS_NAME = distro.linux_distribution()[2]
 REPO_ROOT = os.path.expanduser('~/.RLTest')
 ENTERPRISE_VERSION = '5.2.0'
 ENTERPRISE_SUB_VERSION = '14'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 redis>=3.0.0
 git+https://github.com/Grokzen/redis-py-cluster.git@master
 psutil
+distro>=1.4.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
     install_requires=[
         'redis>=3.0.0',
         'redis-py-cluster@git+ssh://git@github.com/Grokzen/redis-py-cluster.git@master#egg=redis-py-cluster',
-        'psutil'
+        'psutil',
+        'distro>=1.4.0'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Given that on python3.8 the platform package has removed the deprecated `platform.distro()` we should follow the recommended alternative distro package.
This PR addresses it, and fixes #77 