### PR TITLE
Fix: Only removing logs dir on --clear-logs option when it exists

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -310,10 +310,11 @@ class RLTest:
             br.download_binaries()
 
         if self.args.clear_logs:
-            try:
-                shutil.rmtree(self.args.log_dir)
-            except Exception as e:
-                print(e)
+            if os.path.exists(self.args.log_dir):
+                try:
+                    shutil.rmtree(self.args.log_dir)
+                except Exception as e:
+                    print(e)
 
         debugger = None
         if self.args.debugger:

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -314,7 +314,7 @@ class RLTest:
                 try:
                     shutil.rmtree(self.args.log_dir)
                 except Exception as e:
-                    print(e)
+                    print(e, file=sys.stderr)
 
         debugger = None
         if self.args.debugger:


### PR DESCRIPTION
When we have the --clear-logs option enabled RLTest will always try to delete the logs dir even if does not exist causing a ugly error message ( no harm given it continues ):

Example:
```
	MODULE=/root/project/bin/linux-x64-release/****************** \
	CLUSTER=0 \
	GEN=1 AOF=1 SLAVES=1 \
	VALGRIND= \
	../tests/flow/tests.sh
[Errno 2] No such file or directory: './logs'
test_ooo:test_ooo
	[PASS]
```

This is an easy fix that checks if the dir exists prior deleting it. 
cc @danni-m 