### PR TITLE
Add decodeResponse argument to Env

### DIFF
--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -158,7 +158,7 @@ class Env:
         return True
 
     def __init__(self, testName=None, testDescription=None, module=None,
-                 moduleArgs=None, env=None, useSlaves=None, shardsCount=None, decodeResponses=True,
+                 moduleArgs=None, env=None, useSlaves=None, shardsCount=None, decodeResponses=None,
                  useAof=None, forceTcp=False, useTLS=False, tlsCertFile=None, tlsKeyFile=None, tlsCaCertFile=None, logDir=None, redisBinaryPath=None,dmcBinaryPath=None,redisEnterpriseBinaryPath=None ):
 
         self.testName = testName if testName else '%s.%s' % (inspect.getmodule(inspect.currentframe().f_back).__name__, inspect.currentframe().f_back.f_code.co_name)

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -106,6 +106,7 @@ class Defaults:
     proxy_binary = None
     re_binary = None
     re_libdir = None
+    decode_responses = True
     use_aof = False
     use_TLS = False
     tls_cert_file = None
@@ -157,7 +158,7 @@ class Env:
         return True
 
     def __init__(self, testName=None, testDescription=None, module=None,
-                 moduleArgs=None, env=None, useSlaves=None, shardsCount=None,
+                 moduleArgs=None, env=None, useSlaves=None, shardsCount=None, decodeResponses=True,
                  useAof=None, forceTcp=False, useTLS=False, tlsCertFile=None, tlsKeyFile=None, tlsCaCertFile=None, logDir=None, redisBinaryPath=None,dmcBinaryPath=None,redisEnterpriseBinaryPath=None ):
 
         self.testName = testName if testName else '%s.%s' % (inspect.getmodule(inspect.currentframe().f_back).__name__, inspect.currentframe().f_back.f_code.co_name)
@@ -182,6 +183,7 @@ class Env:
         self.env = env if env else Defaults.env
         self.useSlaves = useSlaves if useSlaves else Defaults.use_slaves
         self.shardsCount = shardsCount if shardsCount else Defaults.num_shards
+        self.decodeResponses = decodeResponses if decodeResponses else Defaults.decode_responses
         self.useAof = useAof if useAof else Defaults.use_aof
         self.verbose = Defaults.verbose
         self.logDir = logDir if logDir else Defaults.logdir
@@ -279,6 +281,7 @@ class Env:
             'modulePath': self.module,
             'moduleArgs': self.moduleArgs,
             'useSlaves': self.useSlaves,
+            'decodeResponses': self.decodeResponses,
             'useAof': self.useAof,
             'dbDirPath': self.logDir,
             'debugger': Defaults.debugger,

--- a/RLTest/redis_cluster.py
+++ b/RLTest/redis_cluster.py
@@ -50,7 +50,7 @@ class ClusterEnv(object):
             for shard in self.shards:
                 con = shard.getConnection()
                 status = con.execute_command('CLUSTER', 'INFO')
-                if b'cluster_state:ok' in status:
+                if 'cluster_state:ok' in str(status):
                     ok += 1
             if ok == len(self.shards):
                 for shard in self.shards:

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -18,7 +18,7 @@ SLAVE = 'slave'
 
 class StandardEnv(object):
     def __init__(self, redisBinaryPath, port=6379, modulePath=None, moduleArgs=None, outputFilesFormat=None,
-                 dbDirPath=None, useSlaves=False, serverId=1, password=None, libPath=None, clusterEnabled=False,
+                 dbDirPath=None, useSlaves=False, serverId=1, password=None, libPath=None, clusterEnabled=False, decodeResponses=True,
                  useAof=False, debugger=None, noCatch=False, unix=False, verbose=False, useTLS=False, tlsCertFile=None,
                  tlsKeyFile=None, tlsCaCertFile=None):
         self.uuid = uuid.uuid4().hex
@@ -31,6 +31,7 @@ class StandardEnv(object):
         self.masterServerId = serverId
         self.password = password
         self.clusterEnabled = clusterEnabled
+        self.decodeResponses = decodeResponses
         self.useAof = useAof
         self.envIsUp = False
         self.debugger = debugger
@@ -325,7 +326,7 @@ class StandardEnv(object):
     def _getConnection(self, role):
         if self.useUnix:
             return redis.StrictRedis(unix_socket_path=self.getUnixPath(role),
-                                     password=self.password)
+                                     password=self.password, decode_responses=self.decodeResponses)
         elif self.useTLS:
             return redis.StrictRedis('localhost', self.getPort(role),
                                      password=self.password,
@@ -334,10 +335,11 @@ class StandardEnv(object):
                                      ssl_certfile=self.getTLSCertFile(),
                                      ssl_cert_reqs=None,
                                      ssl_ca_certs=self.getTLSCACertFile(),
+                                     decode_responses=self.decodeResponses
                                      )
         else:
             return redis.StrictRedis('localhost', self.getPort(role),
-                                     password=self.password)
+                                     password=self.password, decode_responses=self.decodeResponses)
 
     def getConnection(self, shardId=1):
         return self._getConnection(MASTER)


### PR DESCRIPTION
This PR allows the user to specify the `decode_responses` argument when building a Redis connection.

This simplifies Python 3 compatibility for RedisGraph.