### PR TITLE
CI timeout improvements and codecov fixes; Add and expose at runtime in a standard format the __version__ attribute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build-ubuntu:
     name: Test on ${{ matrix.platform }} with Python ${{ matrix.python }}
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 10
     strategy:
       matrix:
         platform: [ubuntu-latest, ubuntu-16.04]
@@ -63,6 +64,7 @@ jobs:
         cd ..
 
     - name: Unit Test with pytest
+      timeout-minutes: 5
       run: |
         pip install pytest
         TLS_CERT=./tests/unit/tls/redis.crt \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      # Number of commits to fetch. 0 indicates all history for all branches and tags.
+      with:
+        - fetch-depth: ''
     - name: Install OpenSSL development libraries
       run: |
         sudo apt-get -qq update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
       # Number of commits to fetch. 0 indicates all history for all branches and tags.
       with:
-        - fetch-depth: ''
+        fetch-depth: ''
     - name: Install OpenSSL development libraries
       run: |
         sudo apt-get -qq update

--- a/RLTest/__init__.py
+++ b/RLTest/__init__.py
@@ -1,5 +1,6 @@
 from RLTest.env import Env
 from RLTest.redis_std import StandardEnv
+from ._version import __version__
 
 __all__ = [
     'Env',

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -16,6 +16,7 @@ from RLTest.utils import Colors
 from RLTest.loader import TestLoader
 from RLTest.Enterprise import binaryrepo
 from RLTest import debuggers
+from RLTest._version import __version__
 
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -98,6 +99,9 @@ class MyCmd(cmd.Cmd):
 parser = CustomArgumentParser(fromfile_prefix_chars=RLTest_CONFIG_FILE_PREFIX,
                               formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                               description='Test Framework for redis and redis module')
+parser.add_argument(
+    '--version', action='store_const', const=True, default=False,
+    help='Print RLTest version and exit')
 
 parser.add_argument(
     '--module', default=None,
@@ -290,6 +294,10 @@ class RLTest:
         else:
             args = sys.argv[1:]
         self.args = parser.parse_args(args=args)
+
+        if self.args.version:
+            print(Colors.Green('RLTest version {}'.format(__version__)))
+            sys.exit(0)
 
         if self.args.interactive_debugger:
             if self.args.env != 'oss' and self.args.env != 'enterprise':

--- a/RLTest/_version.py
+++ b/RLTest/_version.py
@@ -1,0 +1,4 @@
+
+# This attribute is the only one place that the version number is written down,
+# so there is only one place to change it when the version number changes.
+__version__ = "0.2.1"

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,10 @@
 from setuptools import setup, find_packages
+from RLTest import __version__
 
-
-def read_version(version_file):
-    """
-    Given the input version_file, this function extracts the
-    version info from the __version__ attribute.
-    """
-    version_str = None
-    import re
-    verstrline = open(version_file, "rt").read()
-    VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
-    mo = re.search(VSRE, verstrline, re.M)
-    if mo:
-        version_str = mo.group(1)
-    else:
-        raise RuntimeError("Unable to find version string in %s." % (version_file,))
-    return version_str
 
 setup(
     name='RLTest',
-    version=read_version("RLTest/_version.py"),
+    version=__version__,
     description="Redis Labs Test Framework, allow to run tests on redis and modules on a variety of environments.",
     author='RedisLabs',
     author_email='oss@redislabs.com',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,28 @@
 from setuptools import setup, find_packages
 
+
+def read_version(version_file):
+    """
+    Given the input version_file, this function extracts the
+    version info from the __version__ attribute.
+    """
+    version_str = None
+    import re
+    verstrline = open(version_file, "rt").read()
+    VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+    mo = re.search(VSRE, verstrline, re.M)
+    if mo:
+        version_str = mo.group(1)
+    else:
+        raise RuntimeError("Unable to find version string in %s." % (version_file,))
+    return version_str
+
 setup(
     name='RLTest',
-    version='0.2.1',
+    version=read_version("RLTest/_version.py"),
     description="Redis Labs Test Framework, allow to run tests on redis and modules on a variety of environments.",
+    author='RedisLabs',
+    author_email='oss@redislabs.com',
     packages=find_packages(),
     install_requires=[
         'redis>=3.0.0',

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,4 +1,5 @@
 import os
+from unittest import TestCase
 
 REDIS_BINARY = os.environ.get("REDIS_BINARY", "redis-server")
 REDIS_ENTERPRISE_BINARY = os.environ.get("REDIS_ENTERPRISE_BINARY", None)
@@ -15,3 +16,9 @@ def whereis(program):
                 not os.path.isdir(os.path.join(path, program)):
             return os.path.join(path, program)
     return None
+
+class TestCommon(TestCase):
+
+    def testVersionRuntime(self):
+        import RLTest as rltest_pkg
+        self.assertNotEqual("",rltest_pkg.__version__)


### PR DESCRIPTION
- Add and expose at runtime in a standard format the __version__ attribute
- fix codecov issue with commit depth
- Reduced timeout from 6 hours to 10min for the entire CI workflow. Set timeout of 5min for unit tests.  Here's a discussion on how to standardize this info: https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package