### PR TITLE
AOF+slaves fix 2

### DIFF
--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -413,6 +413,7 @@ class StandardEnv(object):
             conns.append(self.getSlaveConnection())
         if restart:
             for con in conns:
+                self._waitForAOFChild(con)
                 con.bgrewriteaof()
                 self._waitForAOFChild(con)
 


### PR DESCRIPTION
Call _waitForAOFChild() both before and after bgrewriteaof() to avoid conjunctions of AOF rewrite