### PR TITLE
disable save

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ usage: RLTest [-h] [--version] [--module MODULE] [--module-args MODULE_ARGS]
               [--shards-count SHARDS_COUNT] [--download-enterprise-binaries]
               [--proxy-binary-path PROXY_BINARY_PATH]
               [--enterprise-lib-path ENTERPRISE_LIB_PATH] [-r]
-              [--use-aof] [--use-rdb-preamble]
+              [--use-aof] [--use-rdb-preamble] [--disable-save]
               [--debug-print] [-V] [--vg-suppressions VG_SUPPRESSIONS]
               [--vg-options VG_OPTIONS] [--vg-no-leakcheck] [--vg-verbose]
               [--vg-no-fail-on-errors] [-i] [--debugger DEBUGGER] [-s]
@@ -125,6 +125,7 @@ optional arguments:
                         taken down. (default: False)
   --use-aof             use aof instead of rdb (default: False)
   --use-rdb-preamble    use rdb preamble when rewriting aof file (default: True)
+  --disable-save        disable redis save (default: False)
   --debug-print         print debug messages (default: False)
   -V, --vg, --use-valgrind
                         running redis under valgrind (assuming valgrind is

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -280,6 +280,8 @@ parser.add_argument(
 parser.add_argument(
     '--tls-ca-cert-file', default=None, help='/path/to/ca.crt')
 
+parser.add_argument('--disable-save', action="store_true", help='Disable Redis save', default=False, dest='disable_save')
+
 class EnvScopeGuard:
     def __init__(self, runner):
         self.runner = runner
@@ -403,6 +405,7 @@ class RLTest:
         Defaults.cluster_node_timeout = self.args.cluster_node_timeout
         if Defaults.use_unix and Defaults.use_slaves:
             raise Exception('Cannot use unix sockets with slaves')
+        Defaults.disable_save = self.args.disable_save
 
         self.tests = []
         self.testsFailed = []

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -128,6 +128,7 @@ class Defaults:
     randomize_ports = False
     oss_password = None
     cluster_node_timeout = None
+    disable_save = False
 
     def getKwargs(self):
         kwargs = {
@@ -166,7 +167,7 @@ class Env:
                  moduleArgs=None, env=None, useSlaves=None, shardsCount=None, decodeResponses=None,
                  useAof=None, useRdbPreamble=None, forceTcp=False, useTLS=False, tlsCertFile=None, tlsKeyFile=None,
                  tlsCaCertFile=None, logDir=None, redisBinaryPath=None, dmcBinaryPath=None,
-                 redisEnterpriseBinaryPath=None, noDefaultModuleArgs=False, clusterNodeTimeout = None):
+                 redisEnterpriseBinaryPath=None, noDefaultModuleArgs=False, clusterNodeTimeout = None, disableSave = False):
 
         self.testName = testName if testName else '%s.%s' % (inspect.getmodule(inspect.currentframe().f_back).__name__, inspect.currentframe().f_back.f_code.co_name)
         self.testName = self.testName.replace(' ', '_')
@@ -198,6 +199,7 @@ class Env:
         self.dmcBinaryPath = expandBinary(dmcBinaryPath) if dmcBinaryPath else Defaults.proxy_binary
         self.redisEnterpriseBinaryPath = expandBinary(redisEnterpriseBinaryPath) if redisEnterpriseBinaryPath else Defaults.re_binary
         self.clusterNodeTimeout = clusterNodeTimeout if clusterNodeTimeout else Defaults.cluster_node_timeout
+        self.disableSave = disableSave if disableSave else Defaults.disable_save
 
         self.assertionFailedSummary = []
 
@@ -293,7 +295,8 @@ class Env:
             'tlsCertFile': self.tlsCertFile,
             'tlsKeyFile': self.tlsKeyFile,
             'tlsCaCertFile': self.tlsCaCertFile,
-            'clusterNodeTimeout': self.clusterNodeTimeout
+            'clusterNodeTimeout': self.clusterNodeTimeout,
+            'disableSave': self.disableSave
         }
         return kwargs
 

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -21,7 +21,7 @@ class StandardEnv(object):
     def __init__(self, redisBinaryPath, port=6379, modulePath=None, moduleArgs=None, outputFilesFormat=None,
                  dbDirPath=None, useSlaves=False, serverId=1, password=None, libPath=None, clusterEnabled=False, decodeResponses=False,
                  useAof=False, useRdbPreamble=True, debugger=None, noCatch=False, unix=False, verbose=False, useTLS=False, tlsCertFile=None,
-                 tlsKeyFile=None, tlsCaCertFile=None, clusterNodeTimeout = None):
+                 tlsKeyFile=None, tlsCaCertFile=None, clusterNodeTimeout = None, disableSave = False):
         self.uuid = uuid.uuid4().hex
         self.redisBinaryPath = os.path.expanduser(redisBinaryPath) if redisBinaryPath.startswith(
             '~/') else redisBinaryPath
@@ -53,6 +53,7 @@ class StandardEnv(object):
         self.tlsKeyFile = tlsKeyFile
         self.tlsCaCertFile = tlsCaCertFile
         self.clusterNodeTimeout = clusterNodeTimeout
+        self.disableSave = disableSave
 
         if port > 0:
             self.port = port
@@ -169,7 +170,8 @@ class StandardEnv(object):
                             if arg.strip() != '':
                                 args += arg.split(' ')
                         cmdArgs += args
-
+        if self.disableSave:
+            cmdArgs += ['--save', '']
         if self.dbDirPath is not None:
             cmdArgs += ['--dir', self.dbDirPath]
         if self.outputFilesFormat is not None and not self.noCatch:
@@ -193,6 +195,7 @@ class StandardEnv(object):
             cmdArgs += ['--appendfilename', self._getFileName(role, '.aof')]
             if not self.useRdbPreamble:
                 cmdArgs += ['--aof-use-rdb-preamble', 'no']
+               
         if self.useTLS:
             cmdArgs += ['--tls-cert-file', self.getTLSCertFile()]
             cmdArgs += ['--tls-key-file', self.getTLSKeyFile()]


### PR DESCRIPTION
This PR introducse the `--disable-save` flag for setting Redis background save.
Moving from 6.0 to 6.2 generates `MISCONF Redis is configured to save RDB snapshots, but it is currently not able to persist on disk.` errors in some scenarios, like testing with valgrind. This new flag disables the snapshot saves.