### PR TITLE
valgrind exit code is 255

### DIFF
--- a/RLTest/debuggers.py
+++ b/RLTest/debuggers.py
@@ -14,7 +14,7 @@ class Valgrind(object):
     def generate_command(self, logfile=None):
         cmd = ['valgrind']
         if self.fail_on_errors == True:
-            cmd += ['--error-exitcode=1']
+            cmd += ['--error-exitcode=255']
         for option in self.options.split():
             cmd += [option]
         if self.leakcheck:

--- a/tests/unit/test_debuggers.py
+++ b/tests/unit/test_debuggers.py
@@ -7,17 +7,17 @@ class TestValgrind(TestCase):
     def test_generate_command_default(self):
         default_valgrind = Valgrind(options="")
         cmd_args = default_valgrind.generate_command()
-        assert ['valgrind', '--error-exitcode=1', '--leak-check=full', '--errors-for-leak-kinds=definite',
+        assert ['valgrind', '--error-exitcode=255', '--leak-check=full', '--errors-for-leak-kinds=definite',
                 ] == cmd_args
 
     def test_generate_command_supression(self):
         default_valgrind = Valgrind(options="", suppressions="file")
         cmd_args = default_valgrind.generate_command()
-        assert ['valgrind', '--error-exitcode=1', '--leak-check=full', '--errors-for-leak-kinds=definite',
+        assert ['valgrind', '--error-exitcode=255', '--leak-check=full', '--errors-for-leak-kinds=definite',
                 '--suppressions=file'] == cmd_args
 
     def test_generate_command_logfile(self):
         default_valgrind = Valgrind(options="")
         cmd_args = default_valgrind.generate_command('logfile')
-        assert ['valgrind', '--error-exitcode=1', '--leak-check=full', '--errors-for-leak-kinds=definite',
+        assert ['valgrind', '--error-exitcode=255', '--leak-check=full', '--errors-for-leak-kinds=definite',
                 '--log-file=logfile'] == cmd_args


### PR DESCRIPTION
Since Redis 6.2, redis will not allow saving when RDB failed to save. When using valgrind on forks, it may return an error code. We will use 255 error code in valgrind so in case of forked process failure, redis will ignore this value and cwill not treat it as error