### PR TITLE
Added support for parallel tests execution.

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -10,6 +10,7 @@ import inspect
 import unittest
 import time
 import shlex
+from multiprocessing import Process, Queue
 
 from RLTest.env import Env, TestAssertionFailure, Defaults
 from RLTest.utils import Colors, fix_modules, fix_modulesArgs
@@ -264,6 +265,8 @@ parser.add_argument('--randomize-ports',
                     'using default port',
                     default=False, action='store_true')
 
+parser.add_argument('--parallelism', help='Run tests in parallel', default=1, type=int)
+
 parser.add_argument(
     '--collect-only', action='store_true',
     help='Collect the tests and exit')
@@ -421,6 +424,11 @@ class RLTest:
         else:
             self.require_clean_exit = False
 
+        self.parallelism = self.args.parallelism
+        if self.parallelism > 1:
+            self.args.randomize_ports = True
+            Defaults.randomize_ports = True
+
     def _convertArgsType(self):
         pass
 
@@ -483,7 +491,7 @@ class RLTest:
             ret += len(failures)
         return ret
 
-    def handleFailure(self, exception=None, prefix='', testname=None, env=None):
+    def handleFailure(self, testFullName=None, exception=None, prefix='', testname=None, env=None):
         """
         Failure omni-function.
 
@@ -504,10 +512,10 @@ class RLTest:
                 testname = '<unknown>'
 
         if exception:
-            self.printError()
+            self.printError(testFullName if testFullName is not None else '')
             self.printException(exception)
         else:
-            self.printFail()
+            self.printFail(testFullName if testFullName is not None else '')
 
         if env:
             self.addFailuresFromEnv(testname, env)
@@ -519,13 +527,13 @@ class RLTest:
     def _runTest(self, test, numberOfAssertionFailed=0, prefix='', before=None, after=None):
         msgPrefix = test.name
 
-        print(Colors.Cyan(prefix + test.name))
+        testFullName = prefix + test.name
 
         if len(inspect.getargspec(test.target).args) > 0 and not test.is_method:
             try:
                 env = Env(testName=test.name)
             except Exception as e:
-                self.handleFailure(exception=e, prefix=msgPrefix, testname=test.name)
+                self.handleFailure(testFullName=testFullName, exception=e, prefix=msgPrefix, testname=test.name)
                 return 0
 
             fn = lambda: test.target(env)
@@ -543,7 +551,7 @@ class RLTest:
             fn()
             passed = True
         except unittest.SkipTest:
-            self.printSkip()
+            self.printSkip(testFullName)
             return 0
         except TestAssertionFailure:
             if self.args.exit_on_failure:
@@ -557,7 +565,7 @@ class RLTest:
                 after = None
                 raise
 
-            self.handleFailure(exception=err, prefix=msgPrefix,
+            self.handleFailure(testFullName=testFullName, exception=err, prefix=msgPrefix,
                                testname=test.name, env=self.currEnv)
             hasException = True
             passed = False
@@ -569,7 +577,7 @@ class RLTest:
         if self.currEnv:
             numFailed = self.currEnv.getNumberOfFailedAssertion()
             if numFailed > numberOfAssertionFailed:
-                self.handleFailure(prefix=msgPrefix,
+                self.handleFailure(testFullName=testFullName, prefix=msgPrefix,
                                    testname=test.name, env=self.currEnv)
                 passed = False
         elif not hasException:
@@ -584,21 +592,21 @@ class RLTest:
             raw_input('press any button to move to the next test')
 
         if passed:
-            self.printPass()
+            self.printPass(testFullName)
 
         return numFailed
 
-    def printSkip(self):
-        print('\t' + Colors.Green('[SKIP]'))
+    def printSkip(self, name):
+        print('%s:\r\n\t%s' % (Colors.Cyan(name), Colors.Green('[SKIP]')))
 
-    def printFail(self):
-        print('\t' + Colors.Bred('[FAIL]'))
+    def printFail(self, name):
+        print('%s:\r\n\t%s' % (Colors.Cyan(name), Colors.Bred('[FAIL]')))
 
-    def printError(self):
-        print('\t' + Colors.Yellow('[ERROR]'))
+    def printError(self, name):
+        print('%s:\r\n\t%s' % (Colors.Cyan(name), Colors.Bred('[ERROR]')))
 
-    def printPass(self):
-        print('\t' + Colors.Green('[PASS]'))
+    def printPass(self, name):
+        print('%s:\r\n\t%s' % (Colors.Cyan(name), Colors.Green('[PASS]')))
 
     def envScopeGuard(self):
         return EnvScopeGuard(self)
@@ -623,37 +631,71 @@ class RLTest:
             print(Colors.Bred('only one test can be run on interactive-debugger use -t'))
             sys.exit(1)
 
+        jobs = Queue()
         for test in self.loader:
-            with self.envScopeGuard():
-                if test.is_class:
-                    try:
-                        obj = test.create_instance()
+            jobs.put(test, block=False)
+        
+        def run_jobs(jobs, results):
+            done = 0
+            while True:
+                try:
+                    test = jobs.get(block=False)
+                except Exception as e:
+                    break
 
-                    except unittest.SkipTest:
-                        self.printSkip()
-                        continue
+                with self.envScopeGuard():
+                    if test.is_class:
+                        try:
+                            obj = test.create_instance()
 
-                    except Exception as e:
-                        self.printException(e)
-                        self.addFailure(test.name + " [__init__]")
-                        continue
+                        except unittest.SkipTest:
+                            self.printSkip(test.name)
+                            continue
 
-                    print(Colors.Cyan(test.name))
+                        except Exception as e:
+                            self.printException(e)
+                            self.addFailure(test.name + " [__init__]")
+                            continue
 
-                    failures = 0
-                    before = getattr(obj, 'setUp', None)
-                    after = getattr(obj, 'tearDown', None)
-                    for subtest in test.get_functions(obj):
-                        failures += self._runTest(subtest, prefix='\t',
-                                                numberOfAssertionFailed=failures,
-                                                before=before, after=after)
+                        failures = 0
+                        before = getattr(obj, 'setUp', None)
+                        after = getattr(obj, 'tearDown', None)
+                        for subtest in test.get_functions(obj):
+                            failures += self._runTest(subtest, prefix='\t',
+                                                    numberOfAssertionFailed=failures,
+                                                    before=before, after=after)
+                            done += 1
+
+                    else:
+                        self._runTest(test)
                         done += 1
+            self.takeEnvDown(fullShutDown=True)
 
-                else:
-                    self._runTest(test)
-                    done += 1
+            # serialized the results back
+            results.put({'done': done, 'failures': self.testsFailed}, block=False)
 
-        self.takeEnvDown(fullShutDown=True)
+        results = Queue()
+        if self.parallelism == 1:
+            run_jobs(jobs, results)
+        else :
+            processes = []    
+            for i in range(self.parallelism):
+                p = Process(target=run_jobs, args=(jobs,results))
+                processes.append(p)
+                p.start()
+            
+            for p in processes:
+                p.join()
+
+        # join results
+        while True:
+            try:
+                res = results.get(block=False)
+            except Exception as e:
+                break
+            done += res['done']
+            self.testsFailed.extend(res['failures'])
+
         endTime = time.time()
 
         print(Colors.Bold('Test Took: %d sec' % (endTime - startTime)))


### PR DESCRIPTION
The PR adds support for parallel tests execution. It is possible to specify how many parallel tests to run using the new `--parallelism` option (default is 1 as today). Using this flag directly implies random ports (otherwise the tests will not be able
to run in parallel).

When using parallelism greater than 1, RLTest will use python multiprocessing library to run the tests in parallel. In such case, RLTest will create a multiprocessing queue and will put all the test there. Each process will take the next test to run and will execute it until there is no more tests left on the queue. When finished, each process will send the tests results to the main process. The main process will accumulate all the results and will print the final summery.

If parallelism is set to 1, run all the tests on the current process just like it is done today.

To be able to print tests result, change the printings to print the test name and result in an atomic way. Otherwise, running the tests in parallel will cause the printings to override each other and will not be possible to understand which test pass and which failed.