### PR TITLE
Fix race condition on multiprocess queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Install Redis Server test dependencies
       if: steps.cache-redis.outputs.cache-hit != 'true'
       run: |
-        git clone git://github.com/antirez/redis.git --branch unstable --depth 1
+        git clone https://github.com/redis/redis.git --branch unstable --depth 1
         cd redis
         make BUILD_TLS=yes -j
         ./src/redis-server --version

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -639,7 +639,7 @@ class RLTest:
             done = 0
             while True:
                 try:
-                    test = jobs.get(block=False)
+                    test = jobs.get(timeout=0.1)
                 except Exception as e:
                     break
 
@@ -690,7 +690,7 @@ class RLTest:
         # join results
         while True:
             try:
-                res = results.get(block=False)
+                res = results.get(timeout=0.1)
             except Exception as e:
                 break
             done += res['done']


### PR DESCRIPTION
When parallelism is set to 1 there might be a race condition between the time we add a job to the time we fetch it. To avoid this we set timeout on 0.1 sec to fetch the job.