### PR TITLE
Change loader to return serializable objects

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -525,6 +525,8 @@ class RLTest:
             self.addFailure(testname, '<No exception or environment>')
 
     def _runTest(self, test, numberOfAssertionFailed=0, prefix='', before=None, after=None):
+        test.initialize()
+        
         msgPrefix = test.name
 
         testFullName = prefix + test.name
@@ -645,6 +647,7 @@ class RLTest:
 
                 with self.envScopeGuard():
                     if test.is_class:
+                        test.initialize()
                         try:
                             obj = test.create_instance()
 

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -167,7 +167,8 @@ class Env:
                  moduleArgs=None, env=None, useSlaves=None, shardsCount=None, decodeResponses=None,
                  useAof=None, useRdbPreamble=None, forceTcp=False, useTLS=False, tlsCertFile=None, tlsKeyFile=None,
                  tlsCaCertFile=None, logDir=None, redisBinaryPath=None, dmcBinaryPath=None,
-                 redisEnterpriseBinaryPath=None, noDefaultModuleArgs=False, clusterNodeTimeout = None):
+                 redisEnterpriseBinaryPath=None, noDefaultModuleArgs=False, clusterNodeTimeout = None,
+                 freshEnv=False):
 
         self.testName = testName if testName else '%s.%s' % (inspect.getmodule(inspect.currentframe().f_back).__name__, inspect.currentframe().f_back.f_code.co_name)
         self.testName = self.testName.replace(' ', '_')
@@ -202,7 +203,7 @@ class Env:
 
         self.assertionFailedSummary = []
 
-        if Env.RTestInstance and Env.RTestInstance.currEnv and self.compareEnvs(Env.RTestInstance.currEnv):
+        if (not freshEnv) and Env.RTestInstance and Env.RTestInstance.currEnv and self.compareEnvs(Env.RTestInstance.currEnv):
             self.envRunner = Env.RTestInstance.currEnv.envRunner
         else:
             if Env.RTestInstance and Env.RTestInstance.currEnv:

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -16,7 +16,7 @@ class TestFunction(object):
         self.name = '{}:{}'.format(self.modulename, symbol)
 
     def initialize(self):
-        module_file = open(self.filename, 'r')
+        module_file = open(self.filename)
         module = imp.load_module(self.modulename, module_file, self.filename, ('.py', 'r', imp.PY_SOURCE))
         obj = getattr(module, self.symbol)
         self.target = obj
@@ -49,7 +49,7 @@ class TestClass(object):
         self.name = '{}:{}'.format(self.modulename, symbol)
 
     def initialize(self):
-        module_file = open(self.filename, 'r')
+        module_file = open(self.filename)
         module = imp.load_module(self.modulename, module_file, self.filename, ('.py', 'r', imp.PY_SOURCE))
         obj = getattr(module, self.symbol)
         self.clsname = obj.__name__

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -8,39 +8,64 @@ import inspect
 class TestFunction(object):
     is_class = False
 
-    def __init__(self, target, name=None, is_method=False):
-        self.target = target
-        if not name:
-            name = target.__name__
+    def __init__(self, filename, symbol, modulename):
+        self.filename = filename
+        self.symbol = symbol
+        self.modulename = modulename
+        self.is_method = False
+        self.name = '{}:{}'.format(self.modulename, symbol)
 
-        self.name = '{}:{}'.format(target.__module__, name)
-        self.is_method = is_method
+    def initialize(self):
+        module_file = open(self.filename, 'r')
+        module = imp.load_module(self.modulename, module_file, self.filename, ('.py', 'r', imp.PY_SOURCE))
+        obj = getattr(module, self.symbol)
+        self.target = obj
 
     def shortname(self):
         return self.target.__name__
 
+class TestMethod(object):
+    is_class = False
+
+    def __init__(self, obj, name):
+        self.target = obj
+        self.name = name
+        self.is_method = True
+
+    def initialize(self):
+        pass
+
+    def shortname(self):
+        return self.target.__name__
 
 class TestClass(object):
     is_class = True
 
-    def __init__(self, cls, names):
-        self.methnames = names
-        self.clsname = cls.__name__
-        self.cls = cls
-        self.name = '{}:{}'.format(cls.__module__, self.clsname)
+    def __init__(self, filename, symbol, modulename, functions):
+        self.filename = filename
+        self.symbol = symbol
+        self.modulename = modulename
+        self.functions = functions
+        self.name = '{}:{}'.format(self.modulename, symbol)
+
+    def initialize(self):
+        module_file = open(self.filename, 'r')
+        module = imp.load_module(self.modulename, module_file, self.filename, ('.py', 'r', imp.PY_SOURCE))
+        obj = getattr(module, self.symbol)
+        self.clsname = obj.__name__
+        self.cls = obj
 
     def create_instance(self, *args, **kwargs):
         return self.cls(*args, **kwargs)
 
     def get_functions(self, instance):
         fns = []
-        for mname in self.methnames:
+        for mname in self.functions:
             bound = getattr(instance, mname)
             if not callable(bound):
                 continue
-            fns.append(TestFunction(bound,
-                                    name='{}.{}'.format(self.clsname, mname),
-                                    is_method=True))
+            fns.append(TestMethod(bound,
+                                  name='{}:{}.{}'.format(self.modulename, self.clsname, mname)))
         return fns
 
 
@@ -92,9 +117,9 @@ class TestLoader(object):
             if inspect.isclass(obj):
                 methnames = [mname for mname in dir(obj)
                              if self.filter_method(mname)]
-                self.tests.append(TestClass(obj, methnames))
+                self.tests.append(TestClass(filename, symbol, module_name, methnames))
             elif inspect.isfunction(obj):
-                self.tests.append(TestFunction(obj))
+                self.tests.append(TestFunction(filename, symbol, module_name))
 
     def scan_dir(self, testdir):
         for filename in os.listdir(testdir):
@@ -126,7 +151,7 @@ class TestLoader(object):
             if t.is_class:
                 print("\tClass")
                 print("\tFunctions")
-                for m in t.methnames:
+                for m in t.functions:
                     print("\t\t", m)
             else:
                 print("\tFunction")


### PR DESCRIPTION
Now that it is possible for tests to run in parallel it require serialize and deserialize the test to another process. For this to work the test must be serializable. Most of the time it works fine but sometimes (for example when tests are used with decorator) it will not work.

Change loader to return a serializable test. The returned object will hold a metadata about the test (file, and symbol). Each processes will use this information to load the test on spot and run it.