### PR TITLE
Match tests name when setting up env.

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -531,6 +531,9 @@ class RLTest:
 
         testFullName = prefix + test.name
 
+        if not test.is_method:
+            Defaults.curr_test_name = testFullName
+
         if len(inspect.getargspec(test.target).args) > 0 and not test.is_method:
             try:
                 env = Env(testName=test.name)
@@ -648,6 +651,8 @@ class RLTest:
                 with self.envScopeGuard():
                     if test.is_class:
                         test.initialize()
+
+                        Defaults.curr_test_name = test.name
                         try:
                             obj = test.create_instance()
 

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -172,6 +172,8 @@ class Env:
                  freshEnv=False):
 
         self.testName = testName if testName else Defaults.curr_test_name
+        if self.testName is None:
+            self.testName = '%s.%s' % (inspect.getmodule(inspect.currentframe().f_back).__name__, inspect.currentframe().f_back.f_code.co_name)
         self.testName = self.testName.replace(' ', '_')
 
         if testDescription:

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -129,6 +129,7 @@ class Defaults:
     randomize_ports = False
     oss_password = None
     cluster_node_timeout = None
+    curr_test_name = None
 
     def getKwargs(self):
         kwargs = {
@@ -170,7 +171,7 @@ class Env:
                  redisEnterpriseBinaryPath=None, noDefaultModuleArgs=False, clusterNodeTimeout = None,
                  freshEnv=False):
 
-        self.testName = testName if testName else '%s.%s' % (inspect.getmodule(inspect.currentframe().f_back).__name__, inspect.currentframe().f_back.f_code.co_name)
+        self.testName = testName if testName else Defaults.curr_test_name
         self.testName = self.testName.replace(' ', '_')
 
         if testDescription:


### PR DESCRIPTION
This solves the issue where Redis log files are created with `__init__` when used as test class. The log file will now have the test name.