### PR TITLE
Avoid random ports on parallelis.

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -425,9 +425,6 @@ class RLTest:
             self.require_clean_exit = False
 
         self.parallelism = self.args.parallelism
-        if self.parallelism > 1:
-            self.args.randomize_ports = True
-            Defaults.randomize_ports = True
 
     def _convertArgsType(self):
         pass
@@ -640,7 +637,8 @@ class RLTest:
         for test in self.loader:
             jobs.put(test, block=False)
         
-        def run_jobs(jobs, results):
+        def run_jobs(jobs, results, port):
+            Defaults.port = port
             done = 0
             while True:
                 try:
@@ -684,11 +682,13 @@ class RLTest:
 
         results = Queue()
         if self.parallelism == 1:
-            run_jobs(jobs, results)
+            run_jobs(jobs, results, Defaults.port)
         else :
-            processes = []    
+            processes = []
+            currPort = 6379
             for i in range(self.parallelism):
-                p = Process(target=run_jobs, args=(jobs,results))
+                p = Process(target=run_jobs, args=(jobs,results,currPort))
+                currPort += 30 # safe distance for cluster and replicas
                 processes.append(p)
                 p.start()
             

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -685,7 +685,7 @@ class RLTest:
             run_jobs(jobs, results, Defaults.port)
         else :
             processes = []
-            currPort = 6379
+            currPort = Defaults.port
             for i in range(self.parallelism):
                 p = Process(target=run_jobs, args=(jobs,results,currPort))
                 currPort += 30 # safe distance for cluster and replicas

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -204,6 +204,7 @@ class Env:
         self.dmcBinaryPath = expandBinary(dmcBinaryPath) if dmcBinaryPath else Defaults.proxy_binary
         self.redisEnterpriseBinaryPath = expandBinary(redisEnterpriseBinaryPath) if redisEnterpriseBinaryPath else Defaults.re_binary
         self.clusterNodeTimeout = clusterNodeTimeout if clusterNodeTimeout else Defaults.cluster_node_timeout
+        self.port = Defaults.port
 
         self.assertionFailedSummary = []
 
@@ -299,7 +300,8 @@ class Env:
             'tlsCertFile': self.tlsCertFile,
             'tlsKeyFile': self.tlsKeyFile,
             'tlsCaCertFile': self.tlsCaCertFile,
-            'clusterNodeTimeout': self.clusterNodeTimeout
+            'clusterNodeTimeout': self.clusterNodeTimeout,
+            'port': self.port
         }
         return kwargs
 

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -130,6 +130,7 @@ class Defaults:
     oss_password = None
     cluster_node_timeout = None
     curr_test_name = None
+    port=6379
 
     def getKwargs(self):
         kwargs = {

--- a/RLTest/redis_cluster.py
+++ b/RLTest/redis_cluster.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 from rediscluster.connection import SSLClusterConnection, ClusterConnectionPool
 
-import env
 from .redis_std import StandardEnv
 import rediscluster
 import redis
@@ -22,7 +21,7 @@ class ClusterEnv(object):
         useSlaves = kwargs.get('useSlaves', False)
         self.useTLS = kwargs['useTLS']
         self.decodeResponses = kwargs.get('decodeResponses', False)
-        startPort = env.Defaults.port
+        startPort = kwargs.pop('port', 10000)
         totalRedises = self.shardsCount * (2 if useSlaves else 1)
         randomizePorts = kwargs.pop('randomizePorts', False)
         for i in range(0, totalRedises, (2 if useSlaves else 1)):

--- a/RLTest/redis_cluster.py
+++ b/RLTest/redis_cluster.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 from rediscluster.connection import SSLClusterConnection, ClusterConnectionPool
 
+import env
 from .redis_std import StandardEnv
 import rediscluster
 import redis
@@ -21,7 +22,7 @@ class ClusterEnv(object):
         useSlaves = kwargs.get('useSlaves', False)
         self.useTLS = kwargs['useTLS']
         self.decodeResponses = kwargs.get('decodeResponses', False)
-        startPort = 20000
+        startPort = env.Defaults.port
         totalRedises = self.shardsCount * (2 if useSlaves else 1)
         randomizePorts = kwargs.pop('randomizePorts', False)
         for i in range(0, totalRedises, (2 if useSlaves else 1)):

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -12,14 +12,13 @@ import redis
 
 from .random_port import get_random_port
 from .utils import Colors, wait_for_conn, fix_modules, fix_modulesArgs
-import env
 
 MASTER = 'master'
 SLAVE = 'slave'
 
 
 class StandardEnv(object):
-    def __init__(self, redisBinaryPath, port=None, modulePath=None, moduleArgs=None, outputFilesFormat=None,
+    def __init__(self, redisBinaryPath, port=6379, modulePath=None, moduleArgs=None, outputFilesFormat=None,
                  dbDirPath=None, useSlaves=False, serverId=1, password=None, libPath=None, clusterEnabled=False, decodeResponses=False,
                  useAof=False, useRdbPreamble=True, debugger=None, noCatch=False, unix=False, verbose=False, useTLS=False, tlsCertFile=None,
                  tlsKeyFile=None, tlsCaCertFile=None, clusterNodeTimeout = None):
@@ -54,9 +53,6 @@ class StandardEnv(object):
         self.tlsKeyFile = tlsKeyFile
         self.tlsCaCertFile = tlsCaCertFile
         self.clusterNodeTimeout = clusterNodeTimeout
-
-        if port is None:
-            port = env.Defaults.port
 
         if port > 0:
             self.port = port

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -12,13 +12,14 @@ import redis
 
 from .random_port import get_random_port
 from .utils import Colors, wait_for_conn, fix_modules, fix_modulesArgs
+import env
 
 MASTER = 'master'
 SLAVE = 'slave'
 
 
 class StandardEnv(object):
-    def __init__(self, redisBinaryPath, port=6379, modulePath=None, moduleArgs=None, outputFilesFormat=None,
+    def __init__(self, redisBinaryPath, port=None, modulePath=None, moduleArgs=None, outputFilesFormat=None,
                  dbDirPath=None, useSlaves=False, serverId=1, password=None, libPath=None, clusterEnabled=False, decodeResponses=False,
                  useAof=False, useRdbPreamble=True, debugger=None, noCatch=False, unix=False, verbose=False, useTLS=False, tlsCertFile=None,
                  tlsKeyFile=None, tlsCaCertFile=None, clusterNodeTimeout = None):
@@ -53,6 +54,9 @@ class StandardEnv(object):
         self.tlsKeyFile = tlsKeyFile
         self.tlsCaCertFile = tlsCaCertFile
         self.clusterNodeTimeout = clusterNodeTimeout
+
+        if port is None:
+            port = env.Defaults.port
 
         if port > 0:
             self.port = port


### PR DESCRIPTION
When parallelism is used, there is no need for random ports. Each processes gets a port to use from the father processes
and keep using it for all the test. This helps to avoid port collision.