### PR TITLE
Added --tests-file and --failed-tests-file options

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -423,14 +423,21 @@ class RLTest:
         self.loader = TestLoader()
         if self.args.test:
             self.loader.load_spec(self.args.test)
-        if self.args.tests_file:
-            for f in self.args.tests_file:
-                with open(f, 'r') as file:
-                    for line in file.readlines():
-                        if line.startswith('#') or line.strip() == "":
-                            continue
-                        self.loader.load_spec(line.strip())
-        if not self.args.test and not self.args.tests_file:
+        if self.args.tests_file is not None:
+            for fname in self.args.tests_file:
+                try:
+                    with open(fname, 'r') as file:
+                        for line in file.readlines():
+                            if line.startswith('#') or line.strip() == "":
+                                continue
+                            try:
+                                line = line.strip()
+                                self.loader.load_spec(line)
+                            except:
+                                print(Colors.Red('Invalid test {TEST} in file {FILE}'.format(TEST=line, FILE=fname)))
+                except:
+                    print(Colors.Red('Test file {} not found'.format(fname)))
+        if self.args.test is not None and self.args.tests_file is not None:
             self.loader.scan_dir(os.getcwd())
 
         if self.args.collect_only:

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -749,7 +749,7 @@ class RLTest:
         else:
             if self.args.failed_tests_file:
                 with open(self.args.failed_tests_file, 'w') as file:
-                    file.write('')
+                    pass
 
 
 def main():

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -421,23 +421,23 @@ class RLTest:
         self.testsFailed = []
         self.currEnv = None
         self.loader = TestLoader()
-        if self.args.test:
+        if self.args.test is not None:
             self.loader.load_spec(self.args.test)
         if self.args.tests_file is not None:
             for fname in self.args.tests_file:
                 try:
                     with open(fname, 'r') as file:
                         for line in file.readlines():
-                            if line.startswith('#') or line.strip() == "":
+                            line = line.strip()
+                            if line.startswith('#') or line == "":
                                 continue
                             try:
-                                line = line.strip()
                                 self.loader.load_spec(line)
                             except:
                                 print(Colors.Red('Invalid test {TEST} in file {FILE}'.format(TEST=line, FILE=fname)))
                 except:
                     print(Colors.Red('Test file {} not found'.format(fname)))
-        if self.args.test is not None and self.args.tests_file is not None:
+        if self.args.test is None and self.args.tests_file is None:
             self.loader.scan_dir(os.getcwd())
 
         if self.args.collect_only:

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -171,13 +171,13 @@ parser.add_argument(
     help='stop before each test allow gdb attachment')
 
 parser.add_argument(
-    '-t', '--test', action='append', help='test to run, in the form of "file:test"')
+    '-t', '--test', metavar='TEST', action='append', help='test to run, in the form of "file:test"')
 
 parser.add_argument(
-    '-f', '--tests-file', action='append', help='file containing test to run, in the form of "file:test"')
+    '-f', '--tests-file', metavar='FILE', action='append', help='file containing test to run, in the form of "file:test"')
 
 parser.add_argument(
-    '-F', '--failed-tests-file', help='destination file for failed tests')
+    '-F', '--failed-tests-file', metavar='FILE', help='destination file for failed tests')
 
 parser.add_argument(
     '--env-only', action='store_const', const=True, default=False,

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -22,7 +22,6 @@ from RLTest._version import __version__
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-
 RLTest_CONFIG_FILE_PREFIX = '@'
 RLTest_CONFIG_FILE_NAME = 'config.txt'
 

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -736,7 +736,7 @@ class RLTest:
             if self.args.failed_tests_file:
                 with open(self.args.failed_tests_file, 'w') as file:
                     for test, _ in self.testsFailed:
-                        file.write(test + "\n")
+                        file.write(test.split(' ')[0] + "\n")
 
             print(Colors.Bold('Failed Tests Summary:'))
             for group, failures in self.testsFailed:

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -73,13 +73,14 @@ class TestClass(object):
 class TestLoader(object):
     def __init__(self):
         self.tests = []
-        # self.subfilter = None
 
     def load_spec(self, arg):
+        # if arg is a list, load its elements
         if isinstance(arg, list):
             for spec in arg:
                 self.load_spec(spec)
             return
+
         # See what kind of spec this is!
         """
         Load tests from single argument form, e.g. foo.py:BarBaz

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -101,8 +101,7 @@ class TestLoader(object):
             sys.path.append(dirname)
 
         module_name, _ = os.path.splitext(os.path.basename(filename))
-        toplevel_filter = None
-        subfilter = None
+        toplevel_filter, subfilter = None, None
         if varname:
             if '.' in varname:
                 toplevel_filter, subfilter = varname.split('.')

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -114,22 +114,25 @@ class TestLoader(object):
     def load_files(self, module_dir, module_name, toplevel_filter=None, subfilter=None):
         filename = '%s/%s.py' % (module_dir, module_name)
         try:
-            module_file = open(filename, 'r')
-            module = imp.load_module(module_name, module_file, filename,
-                                     ('.py', 'r', imp.PY_SOURCE))
-            for symbol in dir(module):
-                if not self.filter_modulevar(symbol, toplevel_filter):
-                    continue
+            with open(filename, 'r') as module_file:
+                try:
+                    module = imp.load_module(module_name, module_file, filename,
+                                             ('.py', 'r', imp.PY_SOURCE))
+                    for symbol in dir(module):
+                        if not self.filter_modulevar(symbol, toplevel_filter):
+                            continue
 
-                obj = getattr(module, symbol)
-                if inspect.isclass(obj):
-                    methnames = [mname for mname in dir(obj)
-                                 if self.filter_method(mname, subfilter)]
-                    self.tests.append(TestClass(filename, symbol, module_name, methnames))
-                elif inspect.isfunction(obj):
-                    self.tests.append(TestFunction(filename, symbol, module_name))
+                        obj = getattr(module, symbol)
+                        if inspect.isclass(obj):
+                            methnames = [mname for mname in dir(obj)
+                                         if self.filter_method(mname, subfilter)]
+                            self.tests.append(TestClass(filename, symbol, module_name, methnames))
+                        elif inspect.isfunction(obj):
+                            self.tests.append(TestFunction(filename, symbol, module_name))
+                except as x:
+                    print(Colors.Red("Problems in file %s: %s" % (filename, x)))
         except:
-            print(Colors.Bred("File %s not found: skipping" % filename))
+            print(Colors.Red("File %s not found: skipping" % filename))
 
     def scan_dir(self, testdir):
         for filename in os.listdir(testdir):

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -3,6 +3,7 @@ import os
 import sys
 import imp
 import inspect
+from RLTest.utils import Colors
 
 
 class TestFunction(object):
@@ -70,12 +71,15 @@ class TestClass(object):
 
 
 class TestLoader(object):
-    def __init__(self, filter=None):
+    def __init__(self):
         self.tests = []
-        self.toplevel_filter = filter
-        self.subfilter = None
+        # self.subfilter = None
 
     def load_spec(self, arg):
+        if isinstance(arg, list):
+            for spec in arg:
+                self.load_spec(spec)
+            return
         # See what kind of spec this is!
         """
         Load tests from single argument form, e.g. foo.py:BarBaz
@@ -96,30 +100,35 @@ class TestLoader(object):
             sys.path.append(dirname)
 
         module_name, _ = os.path.splitext(os.path.basename(filename))
+        toplevel_filter = None
+        subfilter = None
         if varname:
             if '.' in varname:
-                self.toplevel_filter, self.subfilter = varname.split('.')
+                toplevel_filter, subfilter = varname.split('.')
             else:
-                self.toplevel_filter = varname
+                toplevel_filter = varname
 
-        self.load_files(dirname, module_name)
+        self.load_files(dirname, module_name, toplevel_filter, subfilter)
 
-    def load_files(self, module_dir, module_name):
+    def load_files(self, module_dir, module_name, toplevel_filter=None, subfilter=None):
         filename = '%s/%s.py' % (module_dir, module_name)
-        module_file = open(filename, 'r')
-        module = imp.load_module(module_name, module_file, filename,
-                                 ('.py', 'r', imp.PY_SOURCE))
-        for symbol in dir(module):
-            if not self.filter_modulevar(symbol):
-                continue
+        try:
+            module_file = open(filename, 'r')
+            module = imp.load_module(module_name, module_file, filename,
+                                     ('.py', 'r', imp.PY_SOURCE))
+            for symbol in dir(module):
+                if not self.filter_modulevar(symbol, toplevel_filter):
+                    continue
 
-            obj = getattr(module, symbol)
-            if inspect.isclass(obj):
-                methnames = [mname for mname in dir(obj)
-                             if self.filter_method(mname)]
-                self.tests.append(TestClass(filename, symbol, module_name, methnames))
-            elif inspect.isfunction(obj):
-                self.tests.append(TestFunction(filename, symbol, module_name))
+                obj = getattr(module, symbol)
+                if inspect.isclass(obj):
+                    methnames = [mname for mname in dir(obj)
+                                 if self.filter_method(mname, subfilter)]
+                    self.tests.append(TestClass(filename, symbol, module_name, methnames))
+                elif inspect.isfunction(obj):
+                    self.tests.append(TestFunction(filename, symbol, module_name))
+        except:
+            print(Colors.Bred("File %s not found: skipping" % filename))
 
     def scan_dir(self, testdir):
         for filename in os.listdir(testdir):
@@ -127,17 +136,17 @@ class TestLoader(object):
                 module_name, ext = os.path.splitext(filename)
                 self.load_files(testdir, module_name)
 
-    def filter_modulevar(self, candidate):
+    def filter_modulevar(self, candidate, toplevel_filter):
         if not candidate.lower().startswith('test'):
             return False
-        if self.toplevel_filter and candidate != self.toplevel_filter:
+        if toplevel_filter and candidate != toplevel_filter:
             return False
         return True
 
-    def filter_method(self, candidate):
+    def filter_method(self, candidate, subfilter):
         if not candidate.lower().startswith('test'):
             return False
-        if self.subfilter and candidate != self.subfilter:
+        if subfilter and candidate != subfilter:
             return False
 
         return True

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -129,7 +129,7 @@ class TestLoader(object):
                             self.tests.append(TestClass(filename, symbol, module_name, methnames))
                         elif inspect.isfunction(obj):
                             self.tests.append(TestFunction(filename, symbol, module_name))
-                except as x:
+                except Exception as x:
                     print(Colors.Red("Problems in file %s: %s" % (filename, x)))
         except:
             print(Colors.Red("File %s not found: skipping" % filename))

--- a/RLTest/utils.py
+++ b/RLTest/utils.py
@@ -45,6 +45,10 @@ class Colors(object):
         return '\033[1m' + data + '\033[0m'
 
     @staticmethod
+    def Red(data):
+        return '\033[31m' + data + '\033[0m'
+
+    @staticmethod
     def Bred(data):
         return '\033[31;1m' + data + '\033[0m'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "RLTest"
-version = "0.5.2"
+version = "0.5.3"
 description="Redis Labs Test Framework, allow to run tests on redis and modules on a variety of environments"
 authors = ["RedisLabs <oss@redislabs.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
`--tests-file` (repeatable) allows for specification of a file containing a list of test specs (`file:test`)
`--failed-tests-file` enables writing of failed tests names into a specified file

Also made `--test` repeatable.