### PR TITLE
call process terminate once

### DIFF
--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -331,8 +331,8 @@ class StandardEnv(object):
                         p.wait()
                     except:
                         pass
+            process.terminate()
             while True:
-                process.terminate()
                 if process.poll() is None:  # None returns if the processes is not finished yet, retry until redis exits
                     time.sleep(0.1)
                 else:


### PR DESCRIPTION
if process terminate call in a loop redis did not shutdown cleanly and we see a lot of invalid read in RedisGraph memcheck