### PR TITLE
Revert 54d1b81d as it broke valgrind run.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       if: matrix.python == '3.9' && matrix.platform != 'macos-11'
+      continue-on-error: true
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -78,6 +78,9 @@ class StandardEnv(object):
             self.port = -1
             self.slavePort = -1
 
+        if self.has_interactive_debugger and serverId > 1:
+            assert self.noCatch and not self.useSlaves and not self.clusterEnabled
+
         if self.useUnix:
             if self.clusterEnabled:
                 raise ValueError('Unix sockets cannot be used with cluster mode')
@@ -170,7 +173,7 @@ class StandardEnv(object):
 
     def createCmdArgs(self, role):
         cmdArgs = []
-        if self.debugger and role == MASTER and self.masterServerId == 1:
+        if self.debugger:
             cmdArgs += self.debugger.generate_command(self._getValgrindFilePath(role) if not self.noCatch else None)
 
         cmdArgs += [self.redisBinaryPath]


### PR DESCRIPTION
Revert the changes on https://github.com/RedisLabsModules/RLTest/pull/191
It broke valgrind run, this change cause only the first shard on cluster to run with valgrind.