### PR TITLE
Replace imp module with importlib

### DIFF
--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -116,24 +116,23 @@ class TestLoader(object):
         filename = '%s/%s.py' % (module_dir, module_name)
         try:
             module_spec = importlib.util.spec_from_file_location(module_name, filename)
-            try:
-                module = importlib.util.module_from_spec(module_spec)
-                module_spec.loader.exec_module(module)
-                for symbol in dir(module):
-                    if not self.filter_modulevar(symbol, toplevel_filter):
-                        continue
+            module = importlib.util.module_from_spec(module_spec)
+            module_spec.loader.exec_module(module)
+            for symbol in dir(module):
+                if not self.filter_modulevar(symbol, toplevel_filter):
+                    continue
 
-                    obj = getattr(module, symbol)
-                    if inspect.isclass(obj):
-                        methnames = [mname for mname in dir(obj)
-                                        if self.filter_method(mname, subfilter)]
-                        self.tests.append(TestClass(filename, symbol, module_name, methnames))
-                    elif inspect.isfunction(obj):
-                        self.tests.append(TestFunction(filename, symbol, module_name))
-            except Exception as x:
-                print(Colors.Red("Problems in file %s: %s" % (filename, x)))
-        except:
+                obj = getattr(module, symbol)
+                if inspect.isclass(obj):
+                    methnames = [mname for mname in dir(obj)
+                                    if self.filter_method(mname, subfilter)]
+                    self.tests.append(TestClass(filename, symbol, module_name, methnames))
+                elif inspect.isfunction(obj):
+                    self.tests.append(TestFunction(filename, symbol, module_name))
+        except ImportError:
             print(Colors.Red("File %s not found: skipping" % filename))
+        except Exception as x:
+            print(Colors.Red("Problems in file %s: %s" % (filename, x)))
 
     def scan_dir(self, testdir):
         for filename in os.listdir(testdir):

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -129,7 +129,7 @@ class TestLoader(object):
                     self.tests.append(TestClass(filename, symbol, module_name, methnames))
                 elif inspect.isfunction(obj):
                     self.tests.append(TestFunction(filename, symbol, module_name))
-        except ImportError:
+        except FileNotFoundError:
             print(Colors.Red("File %s not found: skipping" % filename))
         except Exception as x:
             print(Colors.Red("Problems in file %s: %s" % (filename, x)))

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import os
 import sys
-import imp
 import importlib.util
 import inspect
 from RLTest.utils import Colors
@@ -52,8 +51,9 @@ class TestClass(object):
         self.name = '{}:{}'.format(self.modulename, symbol)
 
     def initialize(self):
-        module_file = open(self.filename)
-        module = imp.load_module(self.modulename, module_file, self.filename, ('.py', 'r', imp.PY_SOURCE))
+        module_spec = importlib.util.spec_from_file_location(self.modulename, self.filename)
+        module = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(module)
         obj = getattr(module, self.symbol)
         self.clsname = obj.__name__
         self.cls = obj
@@ -115,23 +115,23 @@ class TestLoader(object):
     def load_files(self, module_dir, module_name, toplevel_filter=None, subfilter=None):
         filename = '%s/%s.py' % (module_dir, module_name)
         try:
-            with open(filename, 'r') as module_file:
-                try:
-                    module = imp.load_module(module_name, module_file, filename,
-                                             ('.py', 'r', imp.PY_SOURCE))
-                    for symbol in dir(module):
-                        if not self.filter_modulevar(symbol, toplevel_filter):
-                            continue
+            module_spec = importlib.util.spec_from_file_location(module_name, filename)
+            try:
+                module = importlib.util.module_from_spec(module_spec)
+                module_spec.loader.exec_module(module)
+                for symbol in dir(module):
+                    if not self.filter_modulevar(symbol, toplevel_filter):
+                        continue
 
-                        obj = getattr(module, symbol)
-                        if inspect.isclass(obj):
-                            methnames = [mname for mname in dir(obj)
-                                         if self.filter_method(mname, subfilter)]
-                            self.tests.append(TestClass(filename, symbol, module_name, methnames))
-                        elif inspect.isfunction(obj):
-                            self.tests.append(TestFunction(filename, symbol, module_name))
-                except Exception as x:
-                    print(Colors.Red("Problems in file %s: %s" % (filename, x)))
+                    obj = getattr(module, symbol)
+                    if inspect.isclass(obj):
+                        methnames = [mname for mname in dir(obj)
+                                        if self.filter_method(mname, subfilter)]
+                        self.tests.append(TestClass(filename, symbol, module_name, methnames))
+                    elif inspect.isfunction(obj):
+                        self.tests.append(TestFunction(filename, symbol, module_name))
+            except Exception as x:
+                print(Colors.Red("Problems in file %s: %s" % (filename, x)))
         except:
             print(Colors.Red("File %s not found: skipping" % filename))
 

--- a/RLTest/loader.py
+++ b/RLTest/loader.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import os
 import sys
 import imp
+import importlib.util
 import inspect
 from RLTest.utils import Colors
 
@@ -17,8 +18,9 @@ class TestFunction(object):
         self.name = '{}:{}'.format(self.modulename, symbol)
 
     def initialize(self):
-        module_file = open(self.filename)
-        module = imp.load_module(self.modulename, module_file, self.filename, ('.py', 'r', imp.PY_SOURCE))
+        module_spec = importlib.util.spec_from_file_location(self.modulename, self.filename)
+        module = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(module)
         obj = getattr(module, self.symbol)
         self.target = obj
 


### PR DESCRIPTION
`imp` is deprecated. RediSearch MacOS CI installs Python 3.12 and can no longer use RLTest if it uses `imp`
This PR replaces the `imp` usage with `importlib.utils` functionality.