### PR TITLE
CI improvement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,3 +208,11 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: true
+
+  pr-validation:
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    steps:
+      - if: contains(needs.*.result, 'failure')
+        run: exit 1


### PR DESCRIPTION
Currently, only one of the matrix sub-jobs is marked as required to pass to approve a PR.

This PR Implements the `pr-validation` job:

- It waits for all the jobs in its `needs` section
- It never skips (only succeeds, fails or cancels)
- it fails if any of its "needed" jobs fails
- if we want additional jobs to be required in the future for PR validation, we just have to add them to the `needs` section

If we make this job the requirement in the repo settings, all the `build` matrix jobs will be required to pass CI.