### PR TITLE
minor improvements and fixes for release workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,7 +14,8 @@ jobs:
 
       - name: get version from tag
         id: get_version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: | # People report that sometimes GITHUB_REF_NAME is empty, so we check for that and fail if so.
+          [[ -n $GITHUB_REF_NAME ]] && echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Set the version for publishing
         uses: ciiiii/toml-editor@1.0.0

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,10 +14,7 @@ jobs:
 
       - name: get version from tag
         id: get_version
-        run: |
-          realversion="${GITHUB_REF/refs\/tags\//}"
-          realversion="${realversion//v/}"
-          echo "::set-output name=VERSION::$realversion"
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Set the version for publishing
         uses: ciiiii/toml-editor@1.0.0
@@ -44,7 +41,7 @@ jobs:
         uses: snok/install-poetry@v1
         with:
           version: 1.2.2
-          virtualens-create: false
+          virtualenvs-create: false
           virtualenvs-in-project: false
           installer-parallel: true
 


### PR DESCRIPTION
1. `::set-output` is deprecated. Changing to the new syntax.
2. simplified step
3. addressing https://github.com/actions/runner/issues/2788
4. typo fix on input for `snok/install-poetry`