### PR TITLE
Disallow combining parallel execution with --no-output-catch

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -489,6 +489,10 @@ class RLTest:
                     print(Colors.Bred('Using `--module` multiple time implies that you specify the `--module-args` in the the same number'))
                     sys.exit(1)
 
+        if self.args.no_output_catch and self.args.parallelism > 1:
+            print(Colors.Bred('No output catch can not be combine with parallel test execution.'))
+            sys.exit(1)
+
         Defaults.module = fix_modules(self.args.module)
         Defaults.module_args = fix_modulesArgs(Defaults.module, self.args.module_args)
         Defaults.env = self.args.env

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -490,7 +490,7 @@ class RLTest:
                     sys.exit(1)
 
         if self.args.no_output_catch and self.args.parallelism > 1:
-            print(Colors.Bred('No output catch can not be combine with parallel test execution.'))
+            print(Colors.Bred('--no-output-catch can not be combine with --parallelism.'))
             sys.exit(1)
 
         Defaults.module = fix_modules(self.args.module)

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -490,7 +490,7 @@ class RLTest:
                     sys.exit(1)
 
         if self.args.no_output_catch and self.args.parallelism > 1:
-            print(Colors.Bred('--no-output-catch can not be combine with --parallelism.'))
+            print(Colors.Bred('--no-output-catch can not be combined with --parallelism.'))
             sys.exit(1)
 
         Defaults.module = fix_modules(self.args.module)


### PR DESCRIPTION
Recent changes that were made on this PR: https://github.com/RedisLabsModules/RLTest/pull/211, changed the way tests results are send to the main processes when parallelism it used. Instead of each processes prints its own output, each processes sends its stdout to the main processes and the main processes prints it. This prevent us from been able to redirect the subprocesses stdout to Redis when using parallelism. Notice that this limitation is not applies when used without parallelism.