### PR TITLE
Set fork as the starting method of a sub-process

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -1004,6 +1004,7 @@ def main():
     sys.stdout = io.open(sys.stdout.fileno(), 'w', encoding='utf8')
     sys.stderr = io.open(sys.stderr.fileno(), 'w', encoding='utf8')
     set_start_method('fork')
+    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES' # For MacOS, to enable fork in multiprocessing
     RLTest().execute()
 
 

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -720,7 +720,7 @@ class RLTest:
         except Exception as err:
             if self.args.exit_on_failure:
                 self.takeEnvDown(fullShutDown=True)
-                after = lambda x=None: None
+                after_func = lambda: None
                 raise
 
             self.handleFailure(testFullName=testFullName, exception=err, prefix=msgPrefix,

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -720,7 +720,7 @@ class RLTest:
         except Exception as err:
             if self.args.exit_on_failure:
                 self.takeEnvDown(fullShutDown=True)
-                after = lambda x=None: None
+                after_func = lambda x=None: None
                 raise
 
             self.handleFailure(testFullName=testFullName, exception=err, prefix=msgPrefix,

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -805,8 +805,8 @@ class RLTest:
                     return 0
 
                 failures = 0
-                before = getattr(obj, 'setUp', None)
-                after = getattr(obj, 'tearDown', None)
+                before = getattr(obj, 'setUp', lambda: None)
+                after = getattr(obj, 'tearDown', lambda: None)
                 for subtest in test.get_functions(obj):
                     with TestTimeLimit(self.args.test_timeout, on_timeout_func):
                         failures += self._runTest(subtest, prefix='\t',

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -12,7 +12,7 @@ import unittest
 import time
 import shlex
 import json
-from multiprocessing import Process, Queue
+from multiprocessing import Process, Queue, set_start_method
 
 from RLTest.env import Env, TestAssertionFailure, Defaults
 from RLTest.utils import Colors, fix_modules, fix_modulesArgs
@@ -1000,9 +1000,10 @@ class RLTest:
 
 
 def main():
-    # Aviod "UnicodeEncodeError: 'ascii' codec can't encode character" errors
+    # Avoid "UnicodeEncodeError: 'ascii' codec can't encode character" errors
     sys.stdout = io.open(sys.stdout.fileno(), 'w', encoding='utf8')
     sys.stderr = io.open(sys.stderr.fileno(), 'w', encoding='utf8')
+    set_start_method('fork')
     RLTest().execute()
 
 

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -805,8 +805,8 @@ class RLTest:
                     return 0
 
                 failures = 0
-                before = getattr(obj, 'setUp', lambda: None)
-                after = getattr(obj, 'tearDown', lambda: None)
+                before = getattr(obj, 'setUp', lambda x=None: None)
+                after = getattr(obj, 'tearDown', lambda x=None: None)
                 for subtest in test.get_functions(obj):
                     with TestTimeLimit(self.args.test_timeout, on_timeout_func):
                         failures += self._runTest(subtest, prefix='\t',

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -399,7 +399,7 @@ class TestTimeLimit(object):
         self.is_done = True
         self.condition.notify(1)
         self.condition.release()
-
+        
 
 class RLTest:
     def __init__(self):
@@ -671,7 +671,7 @@ class RLTest:
         else:
             self.addFailure(testname, '<No exception or environment>')
 
-    def _runTest(self, test, numberOfAssertionFailed=0, prefix='', before=lambda x=None: None, after=lambda x=None: None):
+    def _runTest(self, test, numberOfAssertionFailed=0, prefix='', before=None, after=None):
         test.initialize()
 
         msgPrefix = test.name
@@ -696,8 +696,8 @@ class RLTest:
                 return 0
 
             fn = lambda: test.target(env)
-            before_func = lambda: before(env)
-            after_func = lambda: after(env)
+            before_func = (lambda: before(env)) if before is not None else None
+            after_func = (lambda: after(env)) if after is not None else None
         else:
             fn = test.target
             before_func = before
@@ -705,7 +705,8 @@ class RLTest:
 
         hasException = False
         try:
-            before_func()
+            if before_func:
+                before_func()
             fn()
             passed = True
         except unittest.SkipTest:
@@ -720,7 +721,7 @@ class RLTest:
         except Exception as err:
             if self.args.exit_on_failure:
                 self.takeEnvDown(fullShutDown=True)
-                after = lambda x=None: None
+                after = None
                 raise
 
             self.handleFailure(testFullName=testFullName, exception=err, prefix=msgPrefix,
@@ -728,7 +729,8 @@ class RLTest:
             hasException = True
             passed = False
         finally:
-            after_func()
+            if after_func:
+                after_func()
 
         numFailed = 0
         if self.currEnv:
@@ -769,7 +771,7 @@ class RLTest:
 
     def envScopeGuard(self):
         return EnvScopeGuard(self)
-
+    
     def killEnvWithSegFault(self):
         if self.currEnv and Defaults.print_verbose_information_on_failure:
             try:
@@ -784,7 +786,7 @@ class RLTest:
                 print('Failed %s' % str(e))
         else:
             self.stopEnvWithSegFault()
-
+    
     def run_single_test(self, test, on_timeout_func):
         done = 0
         with self.envScopeGuard():
@@ -829,7 +831,7 @@ class RLTest:
             verboseInfo['after_dispose'] = lastEnv.getInformationAfterDispose()
             lastEnv.debugPrint(json.dumps(verboseInfo, indent=2).replace('\\n', '\n'), force=True)
         return done
-
+    
     def print_failures(self):
         for group, failures in self.testsFailed.items():
             print('\t' + Colors.Bold(group))
@@ -840,7 +842,7 @@ class RLTest:
 
     def disable_progress_bar(self):
         return self.args.no_output_catch or self.args.no_progress or not sys.stdout.isatty()
-
+    
     def progressbar(self, num_elements):
         bar = None
         if not self.disable_progress_bar():
@@ -912,11 +914,12 @@ class RLTest:
                 except Exception as e:
                     break
 
+                
                 output = io.StringIO()
                 with redirect_stdout(output):
                     def on_timeout():
                         nonlocal done
-                        try:
+                        try:    
                             done += 1
                             self.killEnvWithSegFault()
                             self.handleFailure(testFullName=test.name, testname=test.name, error_msg=Colors.Bred('Test timeout'))

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -1005,7 +1005,6 @@ def main():
     sys.stderr = io.open(sys.stderr.fileno(), 'w', encoding='utf8')
     # Set multiprocessing start method to fork, we have unserializable objects in the env
     set_start_method('fork')
-    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES' # For MacOS, to enable fork in multiprocessing
     RLTest().execute()
 
 

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -399,7 +399,7 @@ class TestTimeLimit(object):
         self.is_done = True
         self.condition.notify(1)
         self.condition.release()
-        
+
 
 class RLTest:
     def __init__(self):
@@ -671,7 +671,7 @@ class RLTest:
         else:
             self.addFailure(testname, '<No exception or environment>')
 
-    def _runTest(self, test, numberOfAssertionFailed=0, prefix='', before=None, after=None):
+    def _runTest(self, test, numberOfAssertionFailed=0, prefix='', before=lambda x=None: None, after=lambda x=None: None):
         test.initialize()
 
         msgPrefix = test.name
@@ -696,8 +696,8 @@ class RLTest:
                 return 0
 
             fn = lambda: test.target(env)
-            before_func = (lambda: before(env)) if before is not None else None
-            after_func = (lambda: after(env)) if after is not None else None
+            before_func = lambda: before(env)
+            after_func = lambda: after(env)
         else:
             fn = test.target
             before_func = before
@@ -705,8 +705,7 @@ class RLTest:
 
         hasException = False
         try:
-            if before_func:
-                before_func()
+            before_func()
             fn()
             passed = True
         except unittest.SkipTest:
@@ -721,7 +720,7 @@ class RLTest:
         except Exception as err:
             if self.args.exit_on_failure:
                 self.takeEnvDown(fullShutDown=True)
-                after = None
+                after = lambda x=None: None
                 raise
 
             self.handleFailure(testFullName=testFullName, exception=err, prefix=msgPrefix,
@@ -729,8 +728,7 @@ class RLTest:
             hasException = True
             passed = False
         finally:
-            if after_func:
-                after_func()
+            after_func()
 
         numFailed = 0
         if self.currEnv:
@@ -771,7 +769,7 @@ class RLTest:
 
     def envScopeGuard(self):
         return EnvScopeGuard(self)
-    
+
     def killEnvWithSegFault(self):
         if self.currEnv and Defaults.print_verbose_information_on_failure:
             try:
@@ -786,7 +784,7 @@ class RLTest:
                 print('Failed %s' % str(e))
         else:
             self.stopEnvWithSegFault()
-    
+
     def run_single_test(self, test, on_timeout_func):
         done = 0
         with self.envScopeGuard():
@@ -831,7 +829,7 @@ class RLTest:
             verboseInfo['after_dispose'] = lastEnv.getInformationAfterDispose()
             lastEnv.debugPrint(json.dumps(verboseInfo, indent=2).replace('\\n', '\n'), force=True)
         return done
-    
+
     def print_failures(self):
         for group, failures in self.testsFailed.items():
             print('\t' + Colors.Bold(group))
@@ -842,7 +840,7 @@ class RLTest:
 
     def disable_progress_bar(self):
         return self.args.no_output_catch or self.args.no_progress or not sys.stdout.isatty()
-    
+
     def progressbar(self, num_elements):
         bar = None
         if not self.disable_progress_bar():
@@ -914,12 +912,11 @@ class RLTest:
                 except Exception as e:
                     break
 
-                
                 output = io.StringIO()
                 with redirect_stdout(output):
                     def on_timeout():
                         nonlocal done
-                        try:    
+                        try:
                             done += 1
                             self.killEnvWithSegFault()
                             self.handleFailure(testFullName=test.name, testname=test.name, error_msg=Colors.Bred('Test timeout'))

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -1003,6 +1003,7 @@ def main():
     # Avoid "UnicodeEncodeError: 'ascii' codec can't encode character" errors
     sys.stdout = io.open(sys.stdout.fileno(), 'w', encoding='utf8')
     sys.stderr = io.open(sys.stderr.fileno(), 'w', encoding='utf8')
+    # Set multiprocessing start method to fork, we have unserializable objects in the env
     set_start_method('fork')
     os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES' # For MacOS, to enable fork in multiprocessing
     RLTest().execute()

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -720,7 +720,7 @@ class RLTest:
         except Exception as err:
             if self.args.exit_on_failure:
                 self.takeEnvDown(fullShutDown=True)
-                after_func = lambda: None
+                after = lambda x=None: None
                 raise
 
             self.handleFailure(testFullName=testFullName, exception=err, prefix=msgPrefix,


### PR DESCRIPTION
- Explicitly set the sub-process start method to `'fork'`, as the default method is different among different OSs, and we rely on forking the memory (local functions, global `Defaults` struct, and more)
- Setting some default values in `_runTest` to be no-op callable so we can always call them (and not have to check if they're `None`)