### PR TITLE
Fix colors

### DIFF
--- a/RLTest/utils.py
+++ b/RLTest/utils.py
@@ -56,7 +56,7 @@ class Colors(object):
 
     @staticmethod
     def Gray(data):
-        return '\033[30;1m' + data + '\033[0m'
+        return '\033[90;1m' + data + '\033[0m'
 
     @staticmethod
     def Blue(data):

--- a/RLTest/utils.py
+++ b/RLTest/utils.py
@@ -59,10 +59,6 @@ class Colors(object):
         return '\033[30;1m' + data + '\033[0m'
 
     @staticmethod
-    def Lgray(data):
-        return '\033[30;47m' + data + '\033[0m'
-
-    @staticmethod
     def Blue(data):
         return '\033[34m' + data + '\033[0m'
 


### PR DESCRIPTION
Some environments treat `30` as gray although by the standard it is black
GitHub Actions logs treat it as black, so some messages were very hard to read or even notice.

Fixes:
- `Lgray` wasn't in use (also colors the GB and not the text) - removed
- `Gray` was set to black. Now it is gray (30 -> 90)

check out the standard: https://en.wikipedia.org/wiki/ANSI_escape_code
