### PR TITLE
Fixing pkg_resources not present

### DIFF
--- a/RLTest/_version.py
+++ b/RLTest/_version.py
@@ -1,8 +1,8 @@
 
 # This attribute is the only one place that the version number is written down,
 # so there is only one place to change it when the version number changes.
-import pkg_resources
 try:
+    import pkg_resources
     __version__ = pkg_resources.get_distribution('RLTest').version
-except (pkg_resources.DistributionNotFound, AttributeError):
+except (pkg_resources.DistributionNotFound, AttributeError, ImportError):
     __version__ = "99.99.99"  # like redis modules


### PR DESCRIPTION
This is the first part of a two part fix. pkg_resources exists to help determine the version, in older versions of python. This comes from setuptools, and has since been deprecated. In the case where there is no pkg_resources, for now, we assume we're on master.

Ideally we could rely on metadata, which in turn involves deprecating Python 3.7, or allowing for an import wrapper (see redis-py). Given the number of projects using the current state, this is a lighter weight approach that we could accept now, until we update everything downstream.
