### PR TITLE
Use the absolute path for the valgrind log file

### DIFF
--- a/RLTest/debuggers.py
+++ b/RLTest/debuggers.py
@@ -23,7 +23,7 @@ class Valgrind(object):
             if '--errors-for-leak-kinds=definite' not in self.options:
                     cmd += ['--errors-for-leak-kinds=definite']
         if self.suppressions:
-            cmd += ['--suppressions=' + self.suppressions]
+            cmd += ['--suppressions=' + os.path.abspath(self.suppressions)]
         if logfile:
             cmd += ['--log-file=' + os.path.abspath(logfile)]
         return cmd

--- a/RLTest/debuggers.py
+++ b/RLTest/debuggers.py
@@ -25,7 +25,7 @@ class Valgrind(object):
         if self.suppressions:
             cmd += ['--suppressions=' + self.suppressions]
         if logfile:
-            cmd += ['--log-file=' + logfile]
+            cmd += ['--log-file=' + os.path.abspath(logfile)]
         return cmd
 
 

--- a/tests/unit/test_debuggers.py
+++ b/tests/unit/test_debuggers.py
@@ -13,11 +13,13 @@ class TestValgrind(TestCase):
     def test_generate_command_supression(self):
         default_valgrind = Valgrind(options="", suppressions="file")
         cmd_args = default_valgrind.generate_command()
-        assert ['valgrind', '--error-exitcode=255', '--leak-check=full', '--errors-for-leak-kinds=definite',
-                '--suppressions=file'] == cmd_args
+        assert ['valgrind', '--error-exitcode=255', '--leak-check=full', '--errors-for-leak-kinds=definite'] == cmd_args[:4]
+        assert '--suppressions=' in cmd_args[4]
+        assert 'file' in cmd_args[4]
 
     def test_generate_command_logfile(self):
         default_valgrind = Valgrind(options="")
         cmd_args = default_valgrind.generate_command('logfile')
-        assert ['valgrind', '--error-exitcode=255', '--leak-check=full', '--errors-for-leak-kinds=definite',
-                '--log-file=logfile'] == cmd_args
+        assert ['valgrind', '--error-exitcode=255', '--leak-check=full', '--errors-for-leak-kinds=definite'] == cmd_args[:4]
+        assert '--log-file=' in cmd_args[4]
+        assert 'logfile' in cmd_args[4]


### PR DESCRIPTION
This fixes the issue when the relative path is provided, which causes the process not starting correctly and the tests - failing.