### PR TITLE
Fix the use before assignment

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -605,10 +605,10 @@ class RLTest:
                                    env=self.currEnv)
 
         if needShutdown:
+            flush_ok = True
             if self.currEnv.isUp():
                 try:
                     self.currEnv.flush()
-                    flush_ok = True
                 except:
                     flush_ok = False
             self.currEnv.stop()


### PR DESCRIPTION
Fixes an issue when the environment is being taken down, and the exception occurs due to a variable being used before assignment.