### PR TITLE
Add dualTLS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ optional arguments:
   --unix                Use Unix domain sockets instead of TCP (default:
                         False)
   --randomize-ports     Randomize Redis listening port assignment rather
-                        thanusing default port (default: False)
+                        than using default port (default: False)
   --collect-only        Collect the tests and exit (default: False)
   --tls                 Enable TLS Support and disable the non-TLS port
                         completely. TLS connections will be available at the
@@ -174,6 +174,9 @@ optional arguments:
                         /path/to/redis.key (default: None)
   --tls-ca-cert-file TLS_CA_CERT_FILE
                         /path/to/ca.crt (default: None)
+
+  --dualTLS             Initialize both TLS and non-TLS ports for all shards.
+                        The non-TLS ports will be the TLS ports + 1500.
 
 ```
 

--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -152,6 +152,7 @@ class Defaults:
     terminate_retry_secs = None
     protocol = 2
     redis_config_file = None
+    dualTLS = False
 
     def getKwargs(self):
         kwargs = {
@@ -200,7 +201,7 @@ class Env:
                  tlsCaCertFile=None, tlsPassphrase=None, logDir=None, redisBinaryPath=None, dmcBinaryPath=None,
                  redisEnterpriseBinaryPath=None, noDefaultModuleArgs=False, clusterNodeTimeout = None,
                  freshEnv=False, enableDebugCommand=None, enableModuleCommand=None, enableProtectedConfigs=None, protocol=None,
-                 terminateRetries=None, terminateRetrySecs=None, redisConfigFile=None):
+                 terminateRetries=None, terminateRetrySecs=None, redisConfigFile=None, dualTLS=False):
 
         self.testName = testName if testName else Defaults.curr_test_name
         if self.testName is None:
@@ -251,6 +252,8 @@ class Env:
         self.redisConfigFile = redisConfigFile if redisConfigFile is not None else Defaults.redis_config_file
 
         self.assertionFailedSummary = []
+
+        self.dualTLS = dualTLS if dualTLS else Defaults.dualTLS
 
         if not freshEnv and Env.RTestInstance and Env.RTestInstance.currEnv and self.compareEnvs(Env.RTestInstance.currEnv):
             self.envRunner = Env.RTestInstance.currEnv.envRunner
@@ -367,6 +370,7 @@ class Env:
             'terminateRetries': self.terminateRetries,
             'terminateRetrySecs': self.terminateRetrySecs,
             'redisConfigFile': self.redisConfigFile,
+            'dualTLS': self.dualTLS
         }
         return kwargs
 

--- a/RLTest/redis_cluster.py
+++ b/RLTest/redis_cluster.py
@@ -68,10 +68,6 @@ class ClusterEnv(object):
             if ok == len(self.shards):
                 for shard in self.shards:
                     try:
-                        shard.getConnection().execute_command('FT.CLUSTERREFRESH')
-                    except Exception:
-                        pass
-                    try:
                         shard.getConnection().execute_command('SEARCH.CLUSTERREFRESH')
                     except Exception:
                         pass

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -23,7 +23,7 @@ class StandardEnv(object):
                  useAof=False, useRdbPreamble=True, debugger=None, sanitizer=None, noCatch=False, noLog=False, unix=False, verbose=False, useTLS=False,
                  tlsCertFile=None, tlsKeyFile=None, tlsCaCertFile=None, clusterNodeTimeout=None, tlsPassphrase=None, enableDebugCommand=False, protocol=2,
                  terminateRetries=None, terminateRetrySecs=None, enableProtectedConfigs=False, enableModuleCommand=False, loglevel=None,
-                 redisConfigFile=None
+                 redisConfigFile=None, dualTLS=False
                  ):
         self.uuid = uuid.uuid4().hex
         self.redisBinaryPath = os.path.expanduser(redisBinaryPath) if redisBinaryPath.startswith(
@@ -71,6 +71,7 @@ class StandardEnv(object):
         self.terminateRetries = terminateRetries
         self.terminateRetrySecs = terminateRetrySecs
         self.redisConfigFile = redisConfigFile
+        self.dualTLS = dualTLS
 
         if port > 0:
             self.port = port
@@ -187,7 +188,7 @@ class StandardEnv(object):
 
         if self.port > -1:
             if self.useTLS:
-                cmdArgs += ['--port', str(0), '--tls-port', str(self.getPort(role))]
+                cmdArgs += ['--port', str(self.getPort(role) + 1500) if self.dualTLS else str(0), '--tls-port', str(self.getPort(role))]
             else:
                 cmdArgs += ['--port', str(self.getPort(role))]
         else:


### PR DESCRIPTION
Adds a `dualTLS` mode, that has the shards listening to regular ports while listening to the TLS ports.
The regular ports are set to be the `TLS-port + 1000` for every shard.