### PR TITLE
[MOD-15026] allow passing startup grace

### DIFF
--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -153,6 +153,7 @@ class Defaults:
     protocol = 2
     redis_config_file = None
     dualTLS = False
+    startup_grace_secs = 0.1
 
     def getKwargs(self):
         kwargs = {
@@ -201,7 +202,8 @@ class Env:
                  tlsCaCertFile=None, tlsPassphrase=None, logDir=None, redisBinaryPath=None, dmcBinaryPath=None,
                  redisEnterpriseBinaryPath=None, noDefaultModuleArgs=False, clusterNodeTimeout = None,
                  freshEnv=False, enableDebugCommand=None, enableModuleCommand=None, enableProtectedConfigs=None, protocol=None,
-                 terminateRetries=None, terminateRetrySecs=None, redisConfigFile=None, dualTLS=False):
+                 terminateRetries=None, terminateRetrySecs=None, redisConfigFile=None, dualTLS=False,
+                 startupGraceSecs=None):
 
         self.testName = testName if testName else Defaults.curr_test_name
         if self.testName is None:
@@ -254,6 +256,8 @@ class Env:
         self.assertionFailedSummary = []
 
         self.dualTLS = dualTLS if dualTLS else Defaults.dualTLS
+
+        self.startupGraceSecs = startupGraceSecs if startupGraceSecs is not None else Defaults.startup_grace_secs
 
         if not freshEnv and Env.RTestInstance and Env.RTestInstance.currEnv and self.compareEnvs(Env.RTestInstance.currEnv):
             self.envRunner = Env.RTestInstance.currEnv.envRunner
@@ -372,6 +376,7 @@ class Env:
             'terminateRetrySecs': self.terminateRetrySecs,
             'redisConfigFile': self.redisConfigFile,
             'dualTLS': self.dualTLS,
+            'startupGraceSecs': self.startupGraceSecs,
         }
         return kwargs
 

--- a/RLTest/redis_std.py
+++ b/RLTest/redis_std.py
@@ -23,7 +23,7 @@ class StandardEnv(object):
                  useAof=False, useRdbPreamble=True, debugger=None, sanitizer=None, noCatch=False, noLog=False, unix=False, verbose=False, useTLS=False,
                  tlsCertFile=None, tlsKeyFile=None, tlsCaCertFile=None, clusterNodeTimeout=None, tlsPassphrase=None, enableDebugCommand=False, protocol=2,
                  terminateRetries=None, terminateRetrySecs=None, enableProtectedConfigs=False, enableModuleCommand=False, loglevel=None,
-                 redisConfigFile=None, dualTLS=False
+                 redisConfigFile=None, dualTLS=False, startupGraceSecs=0.1
                  ):
         self.uuid = uuid.uuid4().hex
         self.redisBinaryPath = os.path.expanduser(redisBinaryPath) if redisBinaryPath.startswith(
@@ -72,6 +72,7 @@ class StandardEnv(object):
         self.terminateRetrySecs = terminateRetrySecs
         self.redisConfigFile = redisConfigFile
         self.dualTLS = dualTLS
+        self.startupGraceSecs = startupGraceSecs
 
         if port > 0:
             self.port = port
@@ -381,7 +382,7 @@ class StandardEnv(object):
         if masters and self.masterProcess is None:
             self.masterProcess = subprocess.Popen(args=self.masterCmdArgs, env=self.masterOSEnv, cwd=self.dbDirPath,
                                                   **options)
-            time.sleep(0.1)
+            time.sleep(self.startupGraceSecs)
             if self._isAlive(self.masterProcess):
                 con = self.getConnection()
                 self.waitForRedisToStart(con, self.masterProcess)
@@ -392,7 +393,7 @@ class StandardEnv(object):
                 print(Colors.Green("Redis slave command: " + ' '.join(self.slaveCmdArgs)))
             self.slaveProcess = subprocess.Popen(args=self.slaveCmdArgs, env=self.slaveOSEnv, cwd=self.dbDirPath,
                                                  **options)
-            time.sleep(0.1)
+            time.sleep(self.startupGraceSecs)
             if self._isAlive(self.slaveProcess):
                 con = self.getSlaveConnection()
                 self.waitForRedisToStart(con, self.slaveProcess)


### PR DESCRIPTION
### Why this change

RLTest's `StandardEnv.startEnv` has a hardcoded `time.sleep(0.1)` between `subprocess.Popen(redis-server ...)` and the liveness probe (`_isAlive` + `waitForRedisToStart` → `wait_for_conn`). That 100 ms grace period is the only window during which the framework tolerates a redis-server that exits on its own (e.g. because a `loadmodule` argument was rejected and the server aborted).

For tests that **intentionally** pass invalid module args and expect the server to fail to start, this is racy:

- If redis-server aborts within 100 ms → `_isAlive` returns `False`, `masterProcess` is set to `None`, `Env.__init__` returns cleanly, and the test can assert `not env.isUp()`.
- If redis-server aborts slightly later (common under load, ASAN, macOS, CI) → `_isAlive` returns `True`, the framework opens a connection, and `wait_for_conn` eventually raises `Exception('Redis server is dead ...')`. That exception is raised from inside `Env.__init__` **before** `RTestInstance.currEnv` is assigned, so even when the test's own `try/except` swallows it, the runner reports a spurious `<Environment destroyed>` failure at teardown.

Concretely, this has been making `testconfigMultiTextOffsetDeltaSlopNeg` flaky in RediSearch, where we pass `MULTI_TEXT_SLOP -1` on purpose and expect the module to reject it during init.

### What this PR does

Adds a `startupGraceSecs` parameter (default `0.1`, i.e. identical to the current behavior) to `StandardEnv.__init__` and `Env.__init__`, plumbed through `getEnvKwargs`, and replaces the hardcoded `time.sleep(0.1)` in `startEnv` with `time.sleep(self.startupGraceSecs)`.

Tests that expect the server to abort during module init can then bump the grace period, e.g.:

```python
env = Env(moduleArgs='MULTI_TEXT_SLOP -1', startupGraceSecs=2)
assert not env.isUp()
```

This keeps the liveness probe from racing with the abort without affecting any existing caller.