### PR TITLE
fix(failed_tests_file): correctly iterate testsFailed dict

### DIFF
--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -1067,7 +1067,7 @@ class RLTest:
         if self.testsFailed:
             if self.args.failed_tests_file:
                 with open(self.args.failed_tests_file, 'w') as file:
-                    for test, _ in self.testsFailed:
+                    for test in self.testsFailed:
                         file.write(test.split(' ')[0] + "\n")
 
             print(Colors.Bold('Failed Tests Summary:'))

--- a/RLTest/__main__.py
+++ b/RLTest/__main__.py
@@ -1067,7 +1067,7 @@ class RLTest:
         if self.testsFailed:
             if self.args.failed_tests_file:
                 with open(self.args.failed_tests_file, 'w') as file:
-                    for test in self.testsFailed:
+                    for test in self.testsFailed.keys():
                         file.write(test.split(' ')[0] + "\n")
 
             print(Colors.Bold('Failed Tests Summary:'))


### PR DESCRIPTION
## Bug

`self.testsFailed` is a dict of `{test_name: [failures]}` (built via `setdefault(name, []).extend(...)` in `addFailureToTest`). The `--failed-tests-file` writer in `RLTest/__main__.py` iterates it as:

```python
for test, _ in self.testsFailed:
    file.write(test.split(' ')[0] + "\n")
```

Iterating a dict yields keys (strings). Python then tries to unpack each key into `(test, _)` — which fails for any test name longer than two characters:

```
File "…/RLTest/__main__.py", line 1070, in execute
    for test, _ in self.testsFailed:
        ^^^^^^^
ValueError: too many values to unpack (expected 2)
```

This silently breaks the `--failed-tests-file` (`-F`) feature whenever a run actually has failures: the writer aborts before producing the file, RLTest exits with the unhandled exception, and any downstream tooling that depends on the file sees no output.

## Repro

```
python -m RLTest --module path/to/module.so --failed-tests-file /tmp/failed.txt --test some_failing_test.py
```

Crashes with the traceback above; `/tmp/failed.txt` is empty or missing.

## Fix

Iterate keys directly. The value side wasn't used (just `_`), so this is the smallest correct change:

```python
for test in self.testsFailed:
    file.write(test.split(' ')[0] + "\n")
```

## Why this hasn't been caught

The buggy code only runs when `self.testsFailed` is non-empty AND `--failed-tests-file` is set. Most CI pipelines that use `-F` only see green runs, so the path stays dormant. Surfaced from the RediSearch flaky-test DB work (RediSearch/RediSearch#9869) when failures finally hit the writer.

## Test plan

- [ ] Run a known-failing test with `--failed-tests-file=/tmp/f.txt` → confirm `/tmp/f.txt` lists the failed test names instead of crashing
- [ ] Run a passing test with the same flag → confirm an empty file is created (matches existing behavior of the `else` branch)