### PR TITLE
[MOD-15868/MOD-15876] env: allow substituting Env subclass via Defaults.env_class

### DIFF
--- a/RLTest/env.py
+++ b/RLTest/env.py
@@ -154,6 +154,8 @@ class Defaults:
     redis_config_file = None
     dualTLS = False
     startup_grace_secs = 0.1
+    # Lets a consumer substitute a subclass for bare Env(...) construction (e.g. enterprise test envs).
+    env_class = None
 
     def getKwargs(self):
         kwargs = {
@@ -187,6 +189,11 @@ class Env:
     EnvCompareParams = ['module', 'moduleArgs', 'env', 'useSlaves', 'shardsCount', 'useAof',
                         'useRdbPreamble', 'forceTcp', 'enableDebugCommand', 'enableProtectedConfigs',
                         'enableModuleCommand', 'protocol', 'password']
+
+    def __new__(cls, *args, **kwargs):
+        if cls is Env and Defaults.env_class is not None:
+            cls = Defaults.env_class
+        return super().__new__(cls)
 
     def compareEnvs(self, env):
         if env is None:


### PR DESCRIPTION
Adds a small, generic construction hook so a consumer can substitute an `Env` subclass for bare `Env(...)` construction, without monkeypatching:

- `Defaults.env_class` (default `None`)
- `Env.__new__` returns `Defaults.env_class` when the bare `Env` is constructed and a class is set (the `pathlib.Path`→`PosixPath` idiom).

When `env_class is None` behavior is unchanged, so this is a no-op for existing users. It lets the RediSearch pytest suite run against the enterprise module via a proper `Env` subclass (RediSearch#10205) instead of monkeypatching `Env` in place — covering both fixture-injected `def testX(env)` tests (via `Defaults.env_factory`) and the ~45 files that construct `Env(...)` directly.

No RediSearch-specific logic here; all module-specific behavior stays in the RediSearch suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)